### PR TITLE
refactor: update usage reporter

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -165,11 +165,11 @@ func main() {
 	defer cancel()
 
 	// Start usage reporter
-	usageServiceClient, usageServiceClientConn := external.InitUsageServiceClient()
-	defer usageServiceClientConn.Close()
-	usg := usage.NewUsage(ctx, repository, userServiceClient, usageServiceClient)
-
+	var usg usage.Usage
 	if !config.Config.Server.DisableUsage {
+		usageServiceClient, usageServiceClientConn := external.InitUsageServiceClient()
+		defer usageServiceClientConn.Close()
+		usg = usage.NewUsage(ctx, repository, userServiceClient, usageServiceClient)
 		usg.StartReporter(ctx)
 	}
 

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -10,7 +10,6 @@ import (
 	"regexp"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/rs/cors"
@@ -34,14 +33,10 @@ import (
 	"github.com/instill-ai/connector-backend/pkg/repository"
 	"github.com/instill-ai/connector-backend/pkg/service"
 	"github.com/instill-ai/connector-backend/pkg/usage"
-	"github.com/instill-ai/x/repo"
 	"github.com/instill-ai/x/zapadapter"
 
 	database "github.com/instill-ai/connector-backend/internal/db"
 	connectorPB "github.com/instill-ai/protogen-go/vdp/connector/v1alpha"
-	mgmtPB "github.com/instill-ai/protogen-go/vdp/mgmt/v1alpha"
-	usagePB "github.com/instill-ai/protogen-go/vdp/usage/v1alpha"
-	usageclient "github.com/instill-ai/usage-client/client"
 )
 
 func grpcHandlerFunc(grpcServer *grpc.Server, gwHandler http.Handler, CORSOrigins []string) http.Handler {
@@ -61,25 +56,6 @@ func grpcHandlerFunc(grpcServer *grpc.Server, gwHandler http.Handler, CORSOrigin
 			})),
 		&http2.Server{},
 	)
-}
-
-func startReporter(ctx context.Context, usageServiceClient usagePB.UsageServiceClient, r repository.Repository, mu mgmtPB.UserServiceClient) {
-
-	logger, _ := logger.GetZapLogger()
-
-	version, err := repo.ReadReleaseManifest("release-please/manifest.json")
-	if err != nil {
-		logger.Fatal(err.Error())
-	}
-
-	go func() {
-		time.Sleep(5 * time.Second)
-		usg := usage.NewUsage(r, mu)
-		err = usageclient.StartReporter(ctx, usageServiceClient, usagePB.Session_SERVICE_CONNECTOR, config.Config.Server.Edition, version, usg.RetrieveUsageData)
-		if err != nil {
-			logger.Error(fmt.Sprintf("unable to start reporter: %v\n", err))
-		}
-	}()
 }
 
 func main() {
@@ -189,10 +165,12 @@ func main() {
 	defer cancel()
 
 	// Start usage reporter
+	usageServiceClient, usageServiceClientConn := external.InitUsageServiceClient()
+	defer usageServiceClientConn.Close()
+	usg := usage.NewUsage(ctx, repository, userServiceClient, usageServiceClient)
+
 	if !config.Config.Server.DisableUsage {
-		usageServiceClient, usageServiceClientConn := external.InitUsageServiceClient()
-		defer usageServiceClientConn.Close()
-		startReporter(ctx, usageServiceClient, repository, userServiceClient)
+		usg.StartReporter(ctx)
 	}
 
 	var dialOpts []grpc.DialOption
@@ -238,6 +216,9 @@ func main() {
 	case err := <-errSig:
 		logger.Error(fmt.Sprintf("Fatal error: %v\n", err))
 	case <-quitSig:
+		if !config.Config.Server.DisableUsage {
+			usg.TriggerSingleReporter(ctx)
+		}
 		logger.Info("Shutting down server...")
 		grpcS.GracefulStop()
 	}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.0
 	github.com/iancoleman/strcase v0.2.0
 	github.com/instill-ai/protogen-go v0.3.1-alpha
-	github.com/instill-ai/usage-client v0.1.1-alpha
+	github.com/instill-ai/usage-client v0.1.2-alpha
 	github.com/instill-ai/x v0.1.0-alpha.0.20220706215306-bceeac65f523
 	github.com/jackc/pgconn v1.12.1
 	github.com/knadh/koanf v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -703,14 +703,10 @@ github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/instill-ai/protogen-go v0.2.1-alpha.0.20220815030441-efcd607dc85a h1:HjdZTEpdz7pY7skluy934TJfF1zsfmnDuTSuzznMviM=
-github.com/instill-ai/protogen-go v0.2.1-alpha.0.20220815030441-efcd607dc85a/go.mod h1:d9ebEdwMX2Las4OScym45qbQM+xcBQITqvq/8anTVas=
-github.com/instill-ai/protogen-go v0.3.0-alpha h1:NjZPmBFzfn5eI1CO6yfbQyYjpVwISRBaGiLJHVF3ZLI=
-github.com/instill-ai/protogen-go v0.3.0-alpha/go.mod h1:d9ebEdwMX2Las4OScym45qbQM+xcBQITqvq/8anTVas=
 github.com/instill-ai/protogen-go v0.3.1-alpha h1:gejEAwadzpa41a09O/wTC9l9E/m5KCY9igGrHs4cLuI=
 github.com/instill-ai/protogen-go v0.3.1-alpha/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
-github.com/instill-ai/usage-client v0.1.1-alpha h1:TG1jH82GHjPqmjogQ4I1d8KFY5cBzrskBt9stoARWnU=
-github.com/instill-ai/usage-client v0.1.1-alpha/go.mod h1:Vi+RgL2YNT+hfztD33JzqFl/Y7/SsV+NpWGIjUgig3s=
+github.com/instill-ai/usage-client v0.1.2-alpha h1:aGZKqZSZu4FB4ov1lyaJVIuoD6MQ+zDBUFqSYWVauSE=
+github.com/instill-ai/usage-client v0.1.2-alpha/go.mod h1:Vi+RgL2YNT+hfztD33JzqFl/Y7/SsV+NpWGIjUgig3s=
 github.com/instill-ai/x v0.1.0-alpha.0.20220706215306-bceeac65f523 h1:HsZW2VWEnPhxitcyJEGbuQ9vi2LVsSEA8ezPIkp4VQs=
 github.com/instill-ai/x v0.1.0-alpha.0.20220706215306-bceeac65f523/go.mod h1:/UEx/zFyMo7so2ctBY0pzjmIoJB9Qz5Y4gvwU2FoU74=
 github.com/intel/goresctrl v0.2.0/go.mod h1:+CZdzouYFn5EsxgqAQTEzMfwKwuc0fVdMrT9FCCAVRQ=

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -3,31 +3,54 @@ package usage
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"github.com/instill-ai/connector-backend/config"
 	"github.com/instill-ai/connector-backend/internal/logger"
 	"github.com/instill-ai/connector-backend/pkg/datamodel"
 	"github.com/instill-ai/connector-backend/pkg/repository"
+	"github.com/instill-ai/x/repo"
 
 	connectorPB "github.com/instill-ai/protogen-go/vdp/connector/v1alpha"
 	mgmtPB "github.com/instill-ai/protogen-go/vdp/mgmt/v1alpha"
 	usagePB "github.com/instill-ai/protogen-go/vdp/usage/v1alpha"
+	usageClient "github.com/instill-ai/usage-client/client"
+	usageReporter "github.com/instill-ai/usage-client/reporter"
 )
 
 // Usage interface
 type Usage interface {
 	RetrieveUsageData() interface{}
+	StartReporter(ctx context.Context)
+	TriggerSingleReporter(ctx context.Context)
 }
 
 type usage struct {
 	repository        repository.Repository
 	userServiceClient mgmtPB.UserServiceClient
+	reporter          usageReporter.Reporter
+	version           string
 }
 
 // NewUsage initiates a usage instance
-func NewUsage(r repository.Repository, mu mgmtPB.UserServiceClient) Usage {
+func NewUsage(ctx context.Context, r repository.Repository, mu mgmtPB.UserServiceClient, usc usagePB.UsageServiceClient) Usage {
+	logger, _ := logger.GetZapLogger()
+
+	version, err := repo.ReadReleaseManifest("release-please/manifest.json")
+	if err != nil {
+		logger.Fatal(err.Error())
+	}
+
+	reporter, err := usageClient.InitReporter(ctx, usc, usagePB.Session_SERVICE_MGMT, config.Config.Server.Edition, version)
+	if err != nil {
+		logger.Fatal(err.Error())
+	}
+
 	return &usage{
 		repository:        r,
 		userServiceClient: mu,
+		reporter:          reporter,
+		version:           version,
 	}
 }
 
@@ -166,5 +189,31 @@ func (u *usage) RetrieveUsageData() interface{} {
 		ConnectorUsageData: &usagePB.ConnectorUsageData{
 			Usages: pbConnectorUsageData,
 		},
+	}
+}
+
+func (u *usage) StartReporter(ctx context.Context) {
+	if u.reporter == nil {
+		return
+	}
+
+	logger, _ := logger.GetZapLogger()
+	go func() {
+		time.Sleep(5 * time.Second)
+		err := usageClient.StartReporter(ctx, u.reporter, usagePB.Session_SERVICE_MGMT, config.Config.Server.Edition, u.version, u.RetrieveUsageData)
+		if err != nil {
+			logger.Error(fmt.Sprintf("unable to start reporter: %v\n", err))
+		}
+	}()
+}
+
+func (u *usage) TriggerSingleReporter(ctx context.Context) {
+	if u.reporter == nil {
+		return
+	}
+	logger, _ := logger.GetZapLogger()
+	err := usageClient.SingleReporter(ctx, u.reporter, usagePB.Session_SERVICE_MGMT, config.Config.Server.Edition, u.version, u.RetrieveUsageData())
+	if err != nil {
+		logger.Fatal(err.Error())
 	}
 }


### PR DESCRIPTION
Because

- upgrade usage collection

This commit

- move usage related code into the usage package
- trigger the reporter before shutting down the server
