### PR TITLE
fix: add delete connectors when finishing testing

### DIFF
--- a/integration-test/rest-destination-connector.js
+++ b/integration-test/rest-destination-connector.js
@@ -613,6 +613,10 @@ export function CheckWrite() {
             [`POST /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id}/write response status 200 (classification)`]: (r) => r.status === 200,
         });
 
+        check(http.request("DELETE", `${connectorHost}/v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id}`), {
+            [`DELETE /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id} response status 204`]: (r) => r.status === 204,
+        });
+
         // Write detection output (empty bounding_boxes)
         csvDstConnector = {
             "id": randomString(10),
@@ -641,7 +645,7 @@ export function CheckWrite() {
             sleep(1)
             currentTime = new Date().getTime();
         }
-
+        
         check(http.request("POST", `${connectorHost}/v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id}/write`,
             JSON.stringify({
                 "sync_mode": "SUPPORTED_SYNC_MODES_FULL_REFRESH",
@@ -661,6 +665,10 @@ export function CheckWrite() {
             headers: { "Content-Type": "application/json" }
         }), {
             [`POST /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id}/write response status 200 (detection)`]: (r) => r.status === 200,
+        });
+
+        check(http.request("DELETE", `${connectorHost}/v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id}`), {
+            [`DELETE /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id} response status 204`]: (r) => r.status === 204,
         });
 
         // Write detection output (multiple models)
@@ -713,6 +721,10 @@ export function CheckWrite() {
             [`POST /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id}/write response status 200 (detection)`]: (r) => r.status === 200,
         });
 
+        check(http.request("DELETE", `${connectorHost}/v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id}`), {
+            [`DELETE /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id} response status 204`]: (r) => r.status === 204,
+        });
+
         // Write keypoint output
         csvDstConnector = {
             "id": randomString(10),
@@ -762,6 +774,10 @@ export function CheckWrite() {
             [`POST /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id}/write response status 200 (keypoint)`]: (r) => r.status === 200,
         });
 
+        check(http.request("DELETE", `${connectorHost}/v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id}`), {
+            [`DELETE /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id} response status 204`]: (r) => r.status === 204,
+        });
+
         // Write ocr output
         csvDstConnector = {
             "id": randomString(10),
@@ -809,6 +825,10 @@ export function CheckWrite() {
             headers: { "Content-Type": "application/json" }
         }), {
             [`POST /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id}/write response status 200 (ocr)`]: (r) => r.status === 200,
+        });
+
+        check(http.request("DELETE", `${connectorHost}/v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id}`), {
+            [`DELETE /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id} response status 204`]: (r) => r.status === 204,
         });
 
         // Write unspecified output

--- a/integration-test/rest.js
+++ b/integration-test/rest.js
@@ -58,3 +58,33 @@ export default function (data) {
   destinationConnector.CheckWrite()
 
 }
+
+export function teardown(data) {
+  group("Connector API: Delete all source connector created by this test", () => {
+    for (const srcConnector of http
+      .request("GET", `${connectorHost}/v1alpha/source-connectors`)
+      .json("source_connectors")) {
+      check(
+        http.request("DELETE", `${connectorHost}/v1alpha/source-connectors/${srcConnector.id}`),
+        {
+          [`DELETE /v1alpha/source-connectors/${srcConnector.id} response status is 204`]: (r) =>
+            r.status === 204,
+        }
+      );
+    }
+  });
+
+  group("Connector API: Delete all destination connector created by this test", () => {
+    for (const desConnector of http
+      .request("GET", `${connectorHost}/v1alpha/destination-connectors`)
+      .json("destination_connectors")) {
+      check(
+        http.request("DELETE", `${connectorHost}/v1alpha/destination-connectors/${desConnector.id}`),
+        {
+          [`DELETE /v1alpha/destination-connectors/${desConnector.id} response status is 204`]: (r) =>
+            r.status === 204,
+        }
+      );
+    }
+  });  
+}


### PR DESCRIPTION

Because

- integration test failed from 2nd running because created connectors is not cleaned

This commit

- add delete connectors after each test case and all created connectors in the teardown function
