### PR TITLE
chore: update model instance name of dummy GitHub model

### DIFF
--- a/integration-test/const.js
+++ b/integration-test/const.js
@@ -52,7 +52,7 @@ export const csvDstConfig = {
 export const clsModelInstOutputs = [
   {
     "task": "TASK_CLASSIFICATION",
-    "model_instance": "models/dummy-model/instances/v1.0",
+    "model_instance": "models/dummy-model/instances/v1.0-cpu",
     "task_outputs": [
       {
         "index": "01GB5T5ZK9W9C2VXMWWRYM8WPS",
@@ -68,7 +68,7 @@ export const clsModelInstOutputs = [
 export const detectionModelInstOutputs = [
   {
     "task": "TASK_DETECTION",
-    "model_instance": "models/dummy-model/instances/v1.0",
+    "model_instance": "models/dummy-model/instances/v1.0-cpu",
     "task_outputs": [
       {
         "index": "01GB5T5ZK9W9C2VXMWWRYM8WPM",
@@ -125,7 +125,7 @@ export const detectionModelInstOutputs = [
   },
   {
     "task": "TASK_DETECTION",
-    "model_instance": "models/dummy-model/instances/v2.0",
+    "model_instance": "models/dummy-model/instances/v2.0-cpu",
     "task_outputs": [
       {
         "index": "01GB5T5ZK9W9C2VXMWWRYM8WPM",
@@ -185,7 +185,7 @@ export const detectionModelInstOutputs = [
 export const detectionEmptyModelInstOutputs = [
   {
     "task": "TASK_DETECTION",
-    "model_instance": "models/dummy-model/instances/v1.0",
+    "model_instance": "models/dummy-model/instances/v1.0-cpu",
     "task_outputs": [
       {
         "index": "01GB5T5ZK9W9C2VXMWWRYM8WPM",
@@ -200,7 +200,7 @@ export const detectionEmptyModelInstOutputs = [
 export const keypointModelInstOutputs = [
   {
     "task": "TASK_KEYPOINT",
-    "model_instance": "models/dummy-model/instances/v1.0",
+    "model_instance": "models/dummy-model/instances/v1.0-cpu",
     "task_outputs": [
       {
         "index": "01GB5T5ZK9W9C2VXMWWRYM8WPT",
@@ -224,7 +224,7 @@ export const keypointModelInstOutputs = [
 export const ocrModelInstOutputs = [
   {
     "task": "TASK_OCR",
-    "model_instance": "models/dummy-model/instances/v1.0",
+    "model_instance": "models/dummy-model/instances/v1.0-cpu",
     "task_outputs": [
       {
         "index": "01GB5T5ZK9W9C2VXMWWRYM8WPU",
@@ -250,7 +250,7 @@ export const ocrModelInstOutputs = [
 export const instSegModelInstOutputs = [
   {
     "task": "TASK_INSTANCE_SEGMENTATION",
-    "model_instance": "models/dummy-model/instances/v1.0",
+    "model_instance": "models/dummy-model/instances/v1.0-cpu",
     "task_outputs": [
       {
         "index": "01GB5T5ZK9W9C2VXMWWRYM8WPU",
@@ -288,7 +288,7 @@ export const instSegModelInstOutputs = [
 export const unspecifiedModelInstOutputs = [
   {
     "task": "TASK_UNSPECIFIED",
-    "model_instance": "models/dummy-model/instances/v1.0",
+    "model_instance": "models/dummy-model/instances/v1.0-cpu",
     "task_outputs": [
       {
         "index": "01GB5T5ZK9W9C2VXMWWRYM8WPV",

--- a/integration-test/rest-destination-connector.js
+++ b/integration-test/rest-destination-connector.js
@@ -601,7 +601,7 @@ export function CheckWrite() {
                 "recipe": {
                     "source": "source-connectors/dummy-source",
                     "model_instances": [
-                        "models/dummy-model/instances/v1.0"
+                        "models/dummy-model/instances/v1.0-cpu"
                     ],
                     "destination": "destination-connectors/dummy-destination",
                 },
@@ -657,8 +657,8 @@ export function CheckWrite() {
                 "recipe": {
                     "source": "source-connectors/dummy-source",
                     "model_instances": [
-                        "models/dummy-model/instances/v1.0",
-                        "models/dummy-model/instances/v2.0"
+                        "models/dummy-model/instances/v1.0-cpu",
+                        "models/dummy-model/instances/v2.0-cpu"
                     ],
                     "destination": "destination-connectors/dummy-destination",
                 },
@@ -714,8 +714,8 @@ export function CheckWrite() {
                 "recipe": {
                     "source": "source-connectors/dummy-source",
                     "model_instances": [
-                        "models/dummy-model/instances/v1.0",
-                        "models/dummy-model/instances/v2.0"
+                        "models/dummy-model/instances/v1.0-cpu",
+                        "models/dummy-model/instances/v2.0-cpu"
                     ],
                     "destination": "destination-connectors/dummy-destination",
                 },
@@ -771,7 +771,7 @@ export function CheckWrite() {
                 "recipe": {
                     "source": "source-connectors/dummy-source",
                     "model_instances": [
-                        "models/dummy-model/instances/v1.0"
+                        "models/dummy-model/instances/v1.0-cpu"
                     ],
                     "destination": "destination-connectors/dummy-destination",
                 },
@@ -827,7 +827,7 @@ export function CheckWrite() {
                 "recipe": {
                     "source": "source-connectors/dummy-source",
                     "model_instances": [
-                        "models/dummy-model/instances/v1.0"
+                        "models/dummy-model/instances/v1.0-cpu"
                     ],
                     "destination": "destination-connectors/dummy-destination",
                 },
@@ -883,7 +883,7 @@ export function CheckWrite() {
                 "recipe": {
                     "source": "source-connectors/dummy-source",
                     "model_instances": [
-                        "models/dummy-model/instances/v1.0"
+                        "models/dummy-model/instances/v1.0-cpu"
                     ],
                     "destination": "destination-connectors/dummy-destination",
                 },
@@ -939,7 +939,7 @@ export function CheckWrite() {
                 "recipe": {
                     "source": "source-connectors/dummy-source",
                     "model_instances": [
-                        "models/dummy-model/instances/v1.0"
+                        "models/dummy-model/instances/v1.0-cpu"
                     ],
                     "destination": "destination-connectors/dummy-destination",
                 },

--- a/integration-test/rest-source-connector.js
+++ b/integration-test/rest-source-connector.js
@@ -297,7 +297,7 @@ export function CheckDelete() {
         const detSyncRecipe = {
             recipe: {
                 source: "source-connectors/source-http",
-                model_instances: [`models/dummy-cls/instances/v1.0`],
+                model_instances: [`models/dummy-cls/instances/v1.0-cpu`],
                 destination: "destination-connectors/destination-http"
             },
         };


### PR DESCRIPTION
Because

- model backend uses a dummy model when running the integration test

This commit

-  update GitHub model tag in integration test