### PR TITLE
fix: use error logs for usage

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -125,10 +125,14 @@ func main() {
 	}
 
 	mgmtAdminServiceClient, mgmtAdminServiceClientConn := external.InitMgmtAdminServiceClient()
-	defer mgmtAdminServiceClientConn.Close()
+	if mgmtAdminServiceClientConn != nil {
+		defer mgmtAdminServiceClientConn.Close()
+	}
 
 	pipelineServiceClient, pipelineServiceClientConn := external.InitPipelineServiceClient()
-	defer pipelineServiceClientConn.Close()
+	if pipelineServiceClientConn != nil {
+		defer pipelineServiceClientConn.Close()
+	}
 
 	repository := repository.NewRepository(db)
 
@@ -168,7 +172,9 @@ func main() {
 	var usg usage.Usage
 	if !config.Config.Server.DisableUsage {
 		usageServiceClient, usageServiceClientConn := external.InitUsageServiceClient()
-		defer usageServiceClientConn.Close()
+		if usageServiceClientConn != nil {
+			defer usageServiceClientConn.Close()
+		}
 		usg = usage.NewUsage(ctx, repository, mgmtAdminServiceClient, usageServiceClient)
 		if usg != nil {
 			usg.StartReporter(ctx)

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -217,6 +217,6 @@ func (u *usage) TriggerSingleReporter(ctx context.Context) {
 	logger, _ := logger.GetZapLogger()
 	err := usageClient.SingleReporter(ctx, u.reporter, usagePB.Session_SERVICE_CONNECTOR, config.Config.Server.Edition, u.version, u.RetrieveUsageData())
 	if err != nil {
-		logger.Fatal(err.Error())
+		logger.Error(fmt.Sprintf("unable to trigger single reporter: %v\n", err))
 	}
 }


### PR DESCRIPTION
Because

- backend service should not be terminated because of connection to other services

This commit

- replace fatal logs with error logs
