### PR TITLE
refactor: update default user id

### DIFF
--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -1,6 +1,6 @@
 package constant
 
 // Constants for resource owner
-const DefaultOwnerID string = "local-user"
+const DefaultOwnerID string = "instill-ai"
 const HeaderOwnerUIDKey = "jwt-sub"
 const HeaderOwnerIDKey = "owner-id"


### PR DESCRIPTION
Because

- we use a more representative user ID

This commit

- update the default user id
