### PR TITLE
chore: change owner from using id to uuid

### DIFF
--- a/integration-test/grpc-destination-connector-private.js
+++ b/integration-test/grpc-destination-connector-private.js
@@ -9,6 +9,7 @@ import {
 } from "https://jslib.k6.io/k6-utils/1.1.0/index.js";
 
 import * as constant from "./const.js"
+import * as helper from "./helper.js"
 
 const clientPrivate = new grpc.Client();
 const clientPublic = new grpc.Client();
@@ -97,6 +98,7 @@ export function CheckList() {
         }, {}), {
             [`vdp.connector.v1alpha.ConnectorPrivateService/ListDestinationConnectorsAdmin pageSize=1 view=VIEW_BASIC response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.connector.v1alpha.ConnectorPrivateService/ListDestinationConnectorsAdmin pageSize=1 view=VIEW_BASIC response destinationConnectors[0].connector.configuration is null`]: (r) => r.message.destinationConnectors[0].connector.configuration === null,
+            [`vdp.connector.v1alpha.ConnectorPrivateService/ListDestinationConnectorsAdmin pageSize=1 view=VIEW_BASIC response destinationConnectors[0].connector.owner is UUID`]: (r) => helper.isValidOwner(r.message.destinationConnectors[0].connector.user),
         });
 
         check(clientPrivate.invoke('vdp.connector.v1alpha.ConnectorPrivateService/ListDestinationConnectorsAdmin', {
@@ -105,6 +107,7 @@ export function CheckList() {
         }, {}), {
             [`vdp.connector.v1alpha.ConnectorPrivateService/ListDestinationConnectorsAdmin pageSize=1 view=VIEW_FULL response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.connector.v1alpha.ConnectorPrivateService/ListDestinationConnectorsAdmin pageSize=1 view=VIEW_FULL response destinationConnectors[0].connector.configuration is null`]: (r) => r.message.destinationConnectors[0].connector.configuration !== null,
+            [`vdp.connector.v1alpha.ConnectorPrivateService/ListDestinationConnectorsAdmin pageSize=1 view=VIEW_FULL response destinationConnectors[0].connector.owner is UUID`]: (r) => helper.isValidOwner(r.message.destinationConnectors[0].connector.user),
         });
 
 
@@ -113,6 +116,7 @@ export function CheckList() {
         }, {}), {
             [`vdp.connector.v1alpha.ConnectorPrivateService/ListDestinationConnectorsAdmin pageSize=1 response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.connector.v1alpha.ConnectorPrivateService/ListDestinationConnectorsAdmin pageSize=1 response destinationConnectors[0].connector.configuration is null`]: (r) => r.message.destinationConnectors[0].connector.configuration === null,
+            [`vdp.connector.v1alpha.ConnectorPrivateService/ListDestinationConnectorsAdmin pageSize=1 response destinationConnectors[0].connector.owner is UUID`]: (r) => helper.isValidOwner(r.message.destinationConnectors[0].connector.user),
         });
 
         check(clientPrivate.invoke('vdp.connector.v1alpha.ConnectorPrivateService/ListDestinationConnectorsAdmin', {
@@ -181,6 +185,7 @@ export function CheckGet() {
             [`vdp.connector.v1alpha.ConnectorPrivateService/GetDestinationConnectorAdmin CSV ${resCSVDst.message.destinationConnector.id} response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.connector.v1alpha.ConnectorPrivateService/GetDestinationConnectorAdmin CSV ${resCSVDst.message.destinationConnector.id} response connector id`]: (r) => r.message.destinationConnector.id === csvDstConnector.id,
             [`vdp.connector.v1alpha.ConnectorPrivateService/GetDestinationConnectorAdmin CSV ${resCSVDst.message.destinationConnector.id} response connector destinationConnectorDefinition permalink`]: (r) => r.message.destinationConnector.destinationConnectorDefinition === constant.csvDstDefRscName,
+            [`vdp.connector.v1alpha.ConnectorPrivateService/GetDestinationConnectorAdmin CSV ${resCSVDst.message.destinationConnector.id} response connector owner is UUID`]: (r) => helper.isValidOwner(r.message.destinationConnector.connector.user),
         });
 
         check(clientPublic.invoke(`vdp.connector.v1alpha.ConnectorPublicService/DeleteDestinationConnector`, {
@@ -224,6 +229,7 @@ export function CheckLookUp() {
             [`vdp.connector.v1alpha.ConnectorPrivateService/LookUpDestinationConnectorAdmin CSV ${resCSVDst.message.destinationConnector.uid} response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.connector.v1alpha.ConnectorPrivateService/LookUpDestinationConnectorAdmin CSV ${resCSVDst.message.destinationConnector.uid} response connector id`]: (r) => r.message.destinationConnector.uid === resCSVDst.message.destinationConnector.uid,
             [`vdp.connector.v1alpha.ConnectorPrivateService/LookUpDestinationConnectorAdmin CSV ${resCSVDst.message.destinationConnector.uid} response connector destinationConnectorDefinition permalink`]: (r) => r.message.destinationConnector.destinationConnectorDefinition === constant.csvDstDefRscName,
+            [`vdp.connector.v1alpha.ConnectorPrivateService/LookUpDestinationConnectorAdmin CSV ${resCSVDst.message.destinationConnector.uid} response connector owner is UUID`]: (r) => helper.isValidOwner(r.message.destinationConnector.connector.user),
         });
 
         check(clientPublic.invoke(`vdp.connector.v1alpha.ConnectorPublicService/DeleteDestinationConnector`, {

--- a/integration-test/grpc-destination-connector-public.js
+++ b/integration-test/grpc-destination-connector-public.js
@@ -40,7 +40,8 @@ export function CheckCreate() {
             "vdp.connector.v1alpha.ConnectorPublicService/CreateDestinationConnector HTTP response StatusOK": (r) => r.status === grpc.StatusOK,
             "vdp.connector.v1alpha.ConnectorPublicService/CreateDestinationConnector HTTP response destinationConnector name": (r) => r.message.destinationConnector.name == `destination-connectors/${httpDstConnector.id}`,
             "vdp.connector.v1alpha.ConnectorPublicService/CreateDestinationConnector HTTP response destinationConnector uid": (r) => helper.isUUID(r.message.destinationConnector.uid),
-            "vdp.connector.v1alpha.ConnectorPublicService/CreateDestinationConnector HTTP response destinationConnector destinationConnectorDefinition": (r) => r.message.destinationConnector.destinationConnectorDefinition === constant.httpDstDefRscName
+            "vdp.connector.v1alpha.ConnectorPublicService/CreateDestinationConnector HTTP response destinationConnector destinationConnectorDefinition": (r) => r.message.destinationConnector.destinationConnectorDefinition === constant.httpDstDefRscName,
+            "vdp.connector.v1alpha.ConnectorPublicService/CreateDestinationConnector HTTP response destinationConnector owner is UUID": (r) => helper.isValidOwner(r.message.destinationConnector.connector.user),
         });
 
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/CreateDestinationConnector', {
@@ -131,7 +132,8 @@ export function CheckCreate() {
             "vdp.connector.v1alpha.ConnectorPublicService/CreateDestinationConnector MySQL response StatusOK": (r) => r.status === grpc.StatusOK,
             "vdp.connector.v1alpha.ConnectorPublicService/CreateDestinationConnector MySQL response destinationConnector name": (r) => r.message.destinationConnector.name == `destination-connectors/${mySQLDstConnector.id}`,
             "vdp.connector.v1alpha.ConnectorPublicService/CreateDestinationConnector MySQL response destinationConnector uid": (r) => helper.isUUID(r.message.destinationConnector.uid),
-            "vdp.connector.v1alpha.ConnectorPublicService/CreateDestinationConnector MySQL response destinationConnector destinationConnectorDefinition": (r) => r.message.destinationConnector.destinationConnectorDefinition === constant.mySQLDstDefRscName
+            "vdp.connector.v1alpha.ConnectorPublicService/CreateDestinationConnector MySQL response destinationConnector destinationConnectorDefinition": (r) => r.message.destinationConnector.destinationConnectorDefinition === constant.mySQLDstDefRscName,
+            "vdp.connector.v1alpha.ConnectorPublicService/CreateDestinationConnector MySQL response destinationConnector owner is UUID": (r) => helper.isValidOwner(r.message.destinationConnector.connector.user),
         });
 
         // Check connector state being updated in 180 secs
@@ -298,6 +300,7 @@ export function CheckList() {
         }, {}), {
             [`vdp.connector.v1alpha.ConnectorPublicService/ListDestinationConnectors pageSize=1 view=VIEW_BASIC response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.connector.v1alpha.ConnectorPublicService/ListDestinationConnectors pageSize=1 view=VIEW_BASIC response destinationConnectors[0].connector.configuration is null`]: (r) => r.message.destinationConnectors[0].connector.configuration === null,
+            [`vdp.connector.v1alpha.ConnectorPublicService/ListDestinationConnectors pageSize=1 view=VIEW_BASIC response destinationConnectors[0].connector.owner is UUID`]: (r) => helper.isValidOwner(r.message.destinationConnectors[0].connector.user),
         });
 
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/ListDestinationConnectors', {
@@ -306,6 +309,7 @@ export function CheckList() {
         }, {}), {
             [`vdp.connector.v1alpha.ConnectorPublicService/ListDestinationConnectors pageSize=1 view=VIEW_FULL response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.connector.v1alpha.ConnectorPublicService/ListDestinationConnectors pageSize=1 view=VIEW_FULL response destinationConnectors[0].connector.configuration is null`]: (r) => r.message.destinationConnectors[0].connector.configuration !== null,
+            [`vdp.connector.v1alpha.ConnectorPublicService/ListDestinationConnectors pageSize=1 view=VIEW_FULL response destinationConnectors[0].connector.owner is UUID`]: (r) => helper.isValidOwner(r.message.destinationConnectors[0].connector.user),
         });
 
 
@@ -314,6 +318,7 @@ export function CheckList() {
         }, {}), {
             [`vdp.connector.v1alpha.ConnectorPublicService/ListDestinationConnectors pageSize=1 response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.connector.v1alpha.ConnectorPublicService/ListDestinationConnectors pageSize=1 response destinationConnectors[0].connector.configuration is null`]: (r) => r.message.destinationConnectors[0].connector.configuration === null,
+            [`vdp.connector.v1alpha.ConnectorPublicService/ListDestinationConnectors pageSize=1 response destinationConnectors[0].connector.owner is UUID`]: (r) => helper.isValidOwner(r.message.destinationConnectors[0].connector.user),
         });
 
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/ListDestinationConnectors', {
@@ -377,6 +382,7 @@ export function CheckGet() {
             [`vdp.connector.v1alpha.ConnectorPublicService/GetDestinationConnector CSV ${resCSVDst.message.destinationConnector.id} response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.connector.v1alpha.ConnectorPublicService/GetDestinationConnector CSV ${resCSVDst.message.destinationConnector.id} response connector id`]: (r) => r.message.destinationConnector.id === csvDstConnector.id,
             [`vdp.connector.v1alpha.ConnectorPublicService/GetDestinationConnector CSV ${resCSVDst.message.destinationConnector.id} response connector destinationConnectorDefinition permalink`]: (r) => r.message.destinationConnector.destinationConnectorDefinition === constant.csvDstDefRscName,
+            [`vdp.connector.v1alpha.ConnectorPublicService/GetDestinationConnector CSV ${resCSVDst.message.destinationConnector.id} response connector owner is UUID`]: (r) => helper.isValidOwner(r.message.destinationConnector.connector.user),
         });
 
         check(client.invoke(`vdp.connector.v1alpha.ConnectorPublicService/DeleteDestinationConnector`, {
@@ -434,6 +440,7 @@ export function CheckUpdate() {
             [`vdp.connector.v1alpha.ConnectorPublicService/UpdateDestinationConnector ${resCSVDstUpdate.message.destinationConnector.id} response connector description`]: (r) => r.message.destinationConnector.connector.description === csvDstConnectorUpdate.connector.description,
             [`vdp.connector.v1alpha.ConnectorPublicService/UpdateDestinationConnector ${resCSVDstUpdate.message.destinationConnector.id} response connector tombstone`]: (r) => r.message.destinationConnector.connector.tombstone === false,
             [`vdp.connector.v1alpha.ConnectorPublicService/UpdateDestinationConnector ${resCSVDstUpdate.message.destinationConnector.id} response connector configuration`]: (r) => r.message.destinationConnector.connector.configuration.destination_path === csvDstConnectorUpdate.connector.configuration.destination_path,
+            [`vdp.connector.v1alpha.ConnectorPublicService/UpdateDestinationConnector ${resCSVDstUpdate.message.destinationConnector.id} response connector owner is UUID`]: (r) => helper.isValidOwner(r.message.destinationConnector.connector.user),
         });
 
         // Try to update with empty description
@@ -452,6 +459,7 @@ export function CheckUpdate() {
         check(resCSVDstUpdate, {
             [`vdp.connector.v1alpha.ConnectorPublicService/UpdateDestinationConnector ${resCSVDstUpdate.message.destinationConnector.id} with empty description response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.connector.v1alpha.ConnectorPublicService/UpdateDestinationConnector ${resCSVDstUpdate.message.destinationConnector.id} with empty description response connector description`]: (r) => r.message.destinationConnector.connector.description === csvDstConnectorUpdate.connector.description,
+            [`vdp.connector.v1alpha.ConnectorPublicService/UpdateDestinationConnector ${resCSVDstUpdate.message.destinationConnector.id} with empty description response connector owner is UUID`]: (r) => helper.isValidOwner(r.message.destinationConnector.connector.user),
         });
 
         // Try to update with a non-existing name field (which should be ignored because name field is OUTPUT_ONLY)
@@ -507,6 +515,7 @@ export function CheckLookUp() {
             [`vdp.connector.v1alpha.ConnectorPublicService/LookUpDestinationConnector CSV ${resCSVDst.message.destinationConnector.uid} response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.connector.v1alpha.ConnectorPublicService/LookUpDestinationConnector CSV ${resCSVDst.message.destinationConnector.uid} response connector id`]: (r) => r.message.destinationConnector.uid === resCSVDst.message.destinationConnector.uid,
             [`vdp.connector.v1alpha.ConnectorPublicService/LookUpDestinationConnector CSV ${resCSVDst.message.destinationConnector.uid} response connector destinationConnectorDefinition permalink`]: (r) => r.message.destinationConnector.destinationConnectorDefinition === constant.csvDstDefRscName,
+            [`vdp.connector.v1alpha.ConnectorPublicService/LookUpDestinationConnector CSV ${resCSVDst.message.destinationConnector.uid} response connector owner is UUID`]: (r) => helper.isValidOwner(r.message.destinationConnector.connector.user),
         });
 
         check(client.invoke(`vdp.connector.v1alpha.ConnectorPublicService/DeleteDestinationConnector`, {

--- a/integration-test/grpc-source-connector-private.js
+++ b/integration-test/grpc-source-connector-private.js
@@ -94,6 +94,7 @@ export function CheckList() {
         }, {}), {
             [`vdp.connector.v1alpha.ConnectorPrivateService/ListSourceConnectorsAdmin pageSize=1 view=VIEW_BASIC response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.connector.v1alpha.ConnectorPrivateService/ListSourceConnectorsAdmin pageSize=1 view=VIEW_BASIC response has sourceConnectors[0].connector.configuration is null`]: (r) => r.message.sourceConnectors[0].connector.configuration === null,
+            [`vdp.connector.v1alpha.ConnectorPrivateService/ListSourceConnectorsAdmin pageSize=1 view=VIEW_BASIC response has sourceConnectors[0].connector.owner is UUID`]: (r) => helper.isValidOwner(r.message.sourceConnectors[0].connector.user),
         });
         check(clientPrivate.invoke('vdp.connector.v1alpha.ConnectorPrivateService/ListSourceConnectorsAdmin', {
             pageSize: 1,
@@ -102,6 +103,7 @@ export function CheckList() {
             [`vdp.connector.v1alpha.ConnectorPrivateService/ListSourceConnectorsAdmin pageSize=1 view=VIEW_FULL response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.connector.v1alpha.ConnectorPrivateService/ListSourceConnectorsAdmin pageSize=1 view=VIEW_FULL response has sourceConnectors[0].connector.configuration is not null`]: (r) => r.message.sourceConnectors[0].connector.configuration !== null,
             [`vdp.connector.v1alpha.ConnectorPrivateService/ListSourceConnectorsAdmin pageSize=1 view=VIEW_FULL response has sourceConnectors[0].connector.configuration is {}`]: (r) => Object.keys(r.message.sourceConnectors[0].connector.configuration).length === 0,
+            [`vdp.connector.v1alpha.ConnectorPrivateService/ListSourceConnectorsAdmin pageSize=1 view=VIEW_FULL response has sourceConnectors[0].connector.owner is UUID`]: (r) => helper.isValidOwner(r.message.sourceConnectors[0].connector.user),
         });
 
         check(clientPrivate.invoke('vdp.connector.v1alpha.ConnectorPrivateService/ListSourceConnectorsAdmin', {
@@ -109,6 +111,7 @@ export function CheckList() {
         }, {}), {
             [`vdp.connector.v1alpha.ConnectorPrivateService/ListSourceConnectorsAdmin pageSize=1 response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.connector.v1alpha.ConnectorPrivateService/ListSourceConnectorsAdmin pageSize=1 response has sourceConnectors[0].connector.configuration is null`]: (r) => r.message.sourceConnectors[0].connector.configuration === null,
+            [`vdp.connector.v1alpha.ConnectorPrivateService/ListSourceConnectorsAdmin pageSize=1 response has sourceConnectors[0].connector.owner is UUID`]: (r) => helper.isValidOwner(r.message.sourceConnectors[0].connector.user),
         });
 
         check(clientPrivate.invoke('vdp.connector.v1alpha.ConnectorPrivateService/ListSourceConnectorsAdmin', {
@@ -160,6 +163,7 @@ export function CheckGet() {
             [`vdp.connector.v1alpha.ConnectorPrivateService/GetSourceConnectorAdmin name=source-connectors/${resHTTP.message.sourceConnector.id} response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.connector.v1alpha.ConnectorPrivateService/GetSourceConnectorAdmin name=source-connectors/${resHTTP.message.sourceConnector.id} response connector id`]: (r) => r.message.sourceConnector.id === httpSrcConnector.id,
             [`vdp.connector.v1alpha.ConnectorPrivateService/GetSourceConnectorAdmin name=source-connectors/${resHTTP.message.sourceConnector.sourceConnectorDefinition} response connector id`]: (r) => r.message.sourceConnector.sourceConnectorDefinition === constant.httpSrcDefRscName,
+            [`vdp.connector.v1alpha.ConnectorPrivateService/GetSourceConnectorAdmin name=source-connectors/${resHTTP.message.sourceConnector.sourceConnectorDefinition} response connector owner is UUID`]: (r) => helper.isValidOwner(r.message.sourceConnector.connector.user),
         });
 
         check(clientPublic.invoke(`vdp.connector.v1alpha.ConnectorPublicService/DeleteSourceConnector`, {
@@ -202,6 +206,7 @@ export function CheckLookUp() {
             [`vdp.connector.v1alpha.ConnectorPrivateService/LookUpSourceConnectorAdmin permalink=source-connectors/${resHTTP.message.sourceConnector.uid} response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.connector.v1alpha.ConnectorPrivateService/LookUpSourceConnectorAdmin permalink=source-connectors/${resHTTP.message.sourceConnector.uid} response connector uid`]: (r) => r.message.sourceConnector.id === httpSrcConnector.id,
             [`vdp.connector.v1alpha.ConnectorPrivateService/LookUpSourceConnectorAdmin permalink=source-connectors/${resHTTP.message.sourceConnector.uid} response connector id`]: (r) => r.message.sourceConnector.sourceConnectorDefinition === constant.httpSrcDefRscName,
+            [`vdp.connector.v1alpha.ConnectorPrivateService/LookUpSourceConnectorAdmin permalink=source-connectors/${resHTTP.message.sourceConnector.uid} response connector owner is UUID`]: (r) => helper.isValidOwner(r.message.sourceConnector.connector.user),
         });
 
         check(clientPublic.invoke(`vdp.connector.v1alpha.ConnectorPublicService/DeleteSourceConnector`, {

--- a/integration-test/grpc-source-connector-public.js
+++ b/integration-test/grpc-source-connector-public.js
@@ -48,7 +48,8 @@ export function CheckCreate() {
             "vdp.connector.v1alpha.ConnectorPublicService/CreateSourceConnector response StatusOK": (r) => r.status === grpc.StatusOK,
             "vdp.connector.v1alpha.ConnectorPublicService/CreateSourceConnector response sourceConnector name": (r) => r.message.sourceConnector.name == `source-connectors/${httpSrcConnector.id}`,
             "vdp.connector.v1alpha.ConnectorPublicService/CreateSourceConnector response sourceConnector uid": (r) => helper.isUUID(r.message.sourceConnector.uid),
-            "vdp.connector.v1alpha.ConnectorPublicService/CreateSourceConnector response sourceConnector sourceConnectorDefinition": (r) => r.message.sourceConnector.sourceConnectorDefinition === constant.httpSrcDefRscName
+            "vdp.connector.v1alpha.ConnectorPublicService/CreateSourceConnector response sourceConnector sourceConnectorDefinition": (r) => r.message.sourceConnector.sourceConnectorDefinition === constant.httpSrcDefRscName,
+            "vdp.connector.v1alpha.ConnectorPublicService/CreateSourceConnector response sourceConnector owner is UUID": (r) => helper.isValidOwner(r.message.sourceConnector.connector.user),
         });
 
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/CreateSourceConnector', {
@@ -163,6 +164,7 @@ export function CheckList() {
         }, {}), {
             [`vdp.connector.v1alpha.ConnectorPublicService/ListSourceConnectors pageSize=1 view=VIEW_BASIC response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.connector.v1alpha.ConnectorPublicService/ListSourceConnectors pageSize=1 view=VIEW_BASIC response has sourceConnectors[0].connector.configuration is null`]: (r) => r.message.sourceConnectors[0].connector.configuration === null,
+            [`vdp.connector.v1alpha.ConnectorPublicService/ListSourceConnectors pageSize=1 view=VIEW_BASIC response has sourceConnectors[0].connector.owner is UUID`]: (r) => helper.isValidOwner(r.message.sourceConnectors[0].connector.user),
         });
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/ListSourceConnectors', {
             pageSize: 1,
@@ -171,6 +173,7 @@ export function CheckList() {
             [`vdp.connector.v1alpha.ConnectorPublicService/ListSourceConnectors pageSize=1 view=VIEW_FULL response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.connector.v1alpha.ConnectorPublicService/ListSourceConnectors pageSize=1 view=VIEW_FULL response has sourceConnectors[0].connector.configuration is not null`]: (r) => r.message.sourceConnectors[0].connector.configuration !== null,
             [`vdp.connector.v1alpha.ConnectorPublicService/ListSourceConnectors pageSize=1 view=VIEW_FULL response has sourceConnectors[0].connector.configuration is {}`]: (r) => Object.keys(r.message.sourceConnectors[0].connector.configuration).length === 0,
+            [`vdp.connector.v1alpha.ConnectorPublicService/ListSourceConnectors pageSize=1 view=VIEW_FULL response has sourceConnectors[0].connector.owner is UUID`]: (r) => helper.isValidOwner(r.message.sourceConnectors[0].connector.user),
         });
 
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/ListSourceConnectors', {
@@ -178,6 +181,7 @@ export function CheckList() {
         }, {}), {
             [`vdp.connector.v1alpha.ConnectorPublicService/ListSourceConnectors pageSize=1 response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.connector.v1alpha.ConnectorPublicService/ListSourceConnectors pageSize=1 response has sourceConnectors[0].connector.configuration is null`]: (r) => r.message.sourceConnectors[0].connector.configuration === null,
+            [`vdp.connector.v1alpha.ConnectorPublicService/ListSourceConnectors pageSize=1 response has sourceConnectors[0].connector.owner is UUID`]: (r) => helper.isValidOwner(r.message.sourceConnectors[0].connector.user),
         });
 
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/ListSourceConnectors', {
@@ -225,6 +229,7 @@ export function CheckGet() {
             [`vdp.connector.v1alpha.ConnectorPublicService/GetSourceConnector name=source-connectors/${resHTTP.message.sourceConnector.id} response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.connector.v1alpha.ConnectorPublicService/GetSourceConnector name=source-connectors/${resHTTP.message.sourceConnector.id} response connector id`]: (r) => r.message.sourceConnector.id === httpSrcConnector.id,
             [`vdp.connector.v1alpha.ConnectorPublicService/GetSourceConnector name=source-connectors/${resHTTP.message.sourceConnector.sourceConnectorDefinition} response connector id`]: (r) => r.message.sourceConnector.sourceConnectorDefinition === constant.httpSrcDefRscName,
+            [`vdp.connector.v1alpha.ConnectorPublicService/GetSourceConnector name=source-connectors/${resHTTP.message.sourceConnector.sourceConnectorDefinition} response connector owner is UUID`]: (r) => helper.isValidOwner(r.message.sourceConnector.connector.user),
         });
 
         check(client.invoke(`vdp.connector.v1alpha.ConnectorPublicService/DeleteSourceConnector`, {
@@ -316,7 +321,7 @@ export function CheckDelete() {
             "model_definition": "model-definitions/github",
             "configuration": {
                 "repository": "instill-ai/model-dummy-cls",
-                "tag": "v1.0-cpu"
+                "tag": "v1.0"
             },
         }), constant.params)
         check(createClsModelRes, {
@@ -445,6 +450,7 @@ export function CheckLookUp() {
             [`vdp.connector.v1alpha.ConnectorPublicService/LookUpSourceConnector permalink=source-connectors/${resHTTP.message.sourceConnector.uid} response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.connector.v1alpha.ConnectorPublicService/LookUpSourceConnector permalink=source-connectors/${resHTTP.message.sourceConnector.uid} response connector uid`]: (r) => r.message.sourceConnector.id === httpSrcConnector.id,
             [`vdp.connector.v1alpha.ConnectorPublicService/LookUpSourceConnector permalink=source-connectors/${resHTTP.message.sourceConnector.uid} response connector id`]: (r) => r.message.sourceConnector.sourceConnectorDefinition === constant.httpSrcDefRscName,
+            [`vdp.connector.v1alpha.ConnectorPublicService/LookUpSourceConnector permalink=source-connectors/${resHTTP.message.sourceConnector.uid} response connector owner is UUID`]: (r) => helper.isValidOwner(r.message.sourceConnector.connector.user),
         });
 
         check(client.invoke(`vdp.connector.v1alpha.ConnectorPublicService/DeleteSourceConnector`, {

--- a/integration-test/helper.js
+++ b/integration-test/helper.js
@@ -11,6 +11,10 @@ export function isUUID(uuid) {
     return regexExp.test(uuid)
 }
 
+export function isValidOwner(user) {
+    return isUUID(user.replace("users/", ""));
+}
+
 export function genHeader(contentType) {
     return {
       "Content-Type": `${contentType}`,

--- a/integration-test/rest-destination-connector-private.js
+++ b/integration-test/rest-destination-connector-private.js
@@ -14,6 +14,7 @@ import {
 } from "./const.js"
 
 import * as constant from "./const.js"
+import * as helper from "./helper.js"
 
 export function CheckList() {
 
@@ -74,16 +75,19 @@ export function CheckList() {
         check(http.request("GET", `${connectorPrivateHost}/v1alpha/admin/destination-connectors?page_size=1&view=VIEW_BASIC`), {
             "GET /v1alpha/admin/destination-connectors?page_size=1&view=VIEW_BASIC response status 200": (r) => r.status === 200,
             "GET /v1alpha/admin/destination-connectors?page_size=1&view=VIEW_BASIC response destination_connectors[0].connector.configuration is null": (r) => r.json().destination_connectors[0].connector.configuration === null,
+            "GET /v1alpha/admin/destination-connectors?page_size=1&view=VIEW_BASIC response destination_connectors[0].connector.owner is UUID": (r) => helper.isValidOwner(r.json().destination_connectors[0].connector.user),
         });
 
         check(http.request("GET", `${connectorPrivateHost}/v1alpha/admin/destination-connectors?page_size=1&view=VIEW_FULL`), {
             "GET /v1alpha/admin/destination-connectors?page_size=1&view=VIEW_FULL response status 200": (r) => r.status === 200,
-            "GET /v1alpha/admin/destination-connectors?page_size=1&view=VIEW_FULL response destination_connectors[0].connector.configuration is not null": (r) => r.json().destination_connectors[0].connector.configuration !== null
+            "GET /v1alpha/admin/destination-connectors?page_size=1&view=VIEW_FULL response destination_connectors[0].connector.configuration is not null": (r) => r.json().destination_connectors[0].connector.configuration !== null,
+            "GET /v1alpha/admin/destination-connectors?page_size=1&view=VIEW_FULL response destination_connectors[0].connector.owner is UUID": (r) => helper.isValidOwner(r.json().destination_connectors[0].connector.user),
         });
 
         check(http.request("GET", `${connectorPrivateHost}/v1alpha/admin/destination-connectors?page_size=1`), {
             "GET /v1alpha/admin/destination-connectors?page_size=1 response status 200": (r) => r.status === 200,
             "GET /v1alpha/admin/destination-connectors?page_size=1 response destination_connectors[0].connector.configuration is null": (r) => r.json().destination_connectors[0].connector.configuration === null,
+            "GET /v1alpha/admin/destination-connectors?page_size=1 response destination_connectors[0].connector.owner is UUID": (r) => helper.isValidOwner(r.json().destination_connectors[0].connector.user),
         });
 
         check(http.request("GET", `${connectorPrivateHost}/v1alpha/admin/destination-connectors?page_size=${limitedRecords.json().total_size}`), {
@@ -132,6 +136,7 @@ export function CheckGet() {
             [`GET /v1alpha/admin/destination-connectors/${resCSVDst.json().destination_connector.id} response status 200`]: (r) => r.status === 200,
             [`GET /v1alpha/admin/destination-connectors/${resCSVDst.json().destination_connector.id} response connector id`]: (r) => r.json().destination_connector.id === csvDstConnector.id,
             [`GET /v1alpha/admin/destination-connectors/${resCSVDst.json().destination_connector.id} response connector destination_connector_definition permalink`]: (r) => r.json().destination_connector.destination_connector_definition === constant.csvDstDefRscName,
+            [`GET /v1alpha/admin/destination-connectors/${resCSVDst.json().destination_connector.id} response connector owner is UUID permalink`]: (r) => helper.isValidOwner(r.json().destination_connector.connector.user),
         });
 
         check(http.request("DELETE", `${connectorPublicHost}/v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id}`), {
@@ -160,6 +165,7 @@ export function CheckLookUp() {
             [`GET /v1alpha/admin/destination-connectors/${resCSVDst.json().destination_connector.uid}/lookUp response status 200`]: (r) => r.status === 200,
             [`GET /v1alpha/admin/destination-connectors/${resCSVDst.json().destination_connector.uid}/lookUp response connector uid`]: (r) => r.json().destination_connector.uid === resCSVDst.json().destination_connector.uid,
             [`GET /v1alpha/admin/destination-connectors/${resCSVDst.json().destination_connector.uid}/lookUp response connector destination_connector_definition`]: (r) => r.json().destination_connector.destination_connector_definition === constant.csvDstDefRscName,
+            [`GET /v1alpha/admin/destination-connectors/${resCSVDst.json().destination_connector.uid}/lookUp response connector owner is UUID`]: (r) => helper.isValidOwner(r.json().destination_connector.connector.user),
         });
 
         check(http.request("DELETE", `${connectorPublicHost}/v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id}`), {

--- a/integration-test/rest-destination-connector-public.js
+++ b/integration-test/rest-destination-connector-public.js
@@ -29,7 +29,8 @@ export function CheckCreate() {
             "POST /v1alpha/destination-connectors response status for creating HTTP destination connector 201": (r) => r.status === 201,
             "POST /v1alpha/destination-connectors response connector name": (r) => r.json().destination_connector.name == `destination-connectors/${httpDstConnector.id}`,
             "POST /v1alpha/destination-connectors response connector uid": (r) => helper.isUUID(r.json().destination_connector.uid),
-            "POST /v1alpha/destination-connectors response connector destination_connector_definition": (r) => r.json().destination_connector.destination_connector_definition === constant.httpDstDefRscName
+            "POST /v1alpha/destination-connectors response connector destination_connector_definition": (r) => r.json().destination_connector.destination_connector_definition === constant.httpDstDefRscName,
+            "POST /v1alpha/destination-connectors response connector owner is UUID": (r) => helper.isValidOwner(r.json().destination_connector.connector.user),
         });
 
         check(http.request(
@@ -120,7 +121,8 @@ export function CheckCreate() {
             "POST /v1alpha/destination-connectors response status for creating MySQL destination connector 201": (r) => r.status === 201,
             "POST /v1alpha/destination-connectors response connector name": (r) => r.json().destination_connector.name == `destination-connectors/${mySQLDstConnector.id}`,
             "POST /v1alpha/destination-connectors response connector uid": (r) => helper.isUUID(r.json().destination_connector.uid),
-            "POST /v1alpha/destination-connectors response connector destination_connector_definition": (r) => r.json().destination_connector.destination_connector_definition === constant.mySQLDstDefRscName
+            "POST /v1alpha/destination-connectors response connector destination_connector_definition": (r) => r.json().destination_connector.destination_connector_definition === constant.mySQLDstDefRscName,
+            "POST /v1alpha/destination-connectors response connector owner is UUID": (r) => helper.isValidOwner(r.json().destination_connector.connector.user),
         });
 
         // Check connector state being updated in 180 secs
@@ -249,16 +251,19 @@ export function CheckList() {
         check(http.request("GET", `${connectorPublicHost}/v1alpha/destination-connectors?page_size=1&view=VIEW_BASIC`), {
             "GET /v1alpha/destination-connectors?page_size=1&view=VIEW_BASIC response status 200": (r) => r.status === 200,
             "GET /v1alpha/destination-connectors?page_size=1&view=VIEW_BASIC response destination_connectors[0].connector.configuration is null": (r) => r.json().destination_connectors[0].connector.configuration === null,
+            "GET /v1alpha/destination-connectors?page_size=1&view=VIEW_BASIC response destination_connectors[0].connector.owner is UUID": (r) => helper.isValidOwner(r.json().destination_connectors[0].connector.user),
         });
 
         check(http.request("GET", `${connectorPublicHost}/v1alpha/destination-connectors?page_size=1&view=VIEW_FULL`), {
             "GET /v1alpha/destination-connectors?page_size=1&view=VIEW_FULL response status 200": (r) => r.status === 200,
-            "GET /v1alpha/destination-connectors?page_size=1&view=VIEW_FULL response destination_connectors[0].connector.configuration is not null": (r) => r.json().destination_connectors[0].connector.configuration !== null
+            "GET /v1alpha/destination-connectors?page_size=1&view=VIEW_FULL response destination_connectors[0].connector.configuration is not null": (r) => r.json().destination_connectors[0].connector.configuration !== null,
+            "GET /v1alpha/destination-connectors?page_size=1&view=VIEW_FULL response destination_connectors[0].connector.owner is UUID": (r) => helper.isValidOwner(r.json().destination_connectors[0].connector.user),
         });
 
         check(http.request("GET", `${connectorPublicHost}/v1alpha/destination-connectors?page_size=1`), {
             "GET /v1alpha/destination-connectors?page_size=1 response status 200": (r) => r.status === 200,
             "GET /v1alpha/destination-connectors?page_size=1 response destination_connectors[0].connector.configuration is null": (r) => r.json().destination_connectors[0].connector.configuration === null,
+            "GET /v1alpha/destination-connectors?page_size=1 response destination_connectors[0].connector.owner is UUID": (r) => helper.isValidOwner(r.json().destination_connectors[0].connector.user),
         });
 
         check(http.request("GET", `${connectorPublicHost}/v1alpha/destination-connectors?page_size=${limitedRecords.json().total_size}`), {
@@ -307,6 +312,7 @@ export function CheckGet() {
             [`GET /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id} response status 200`]: (r) => r.status === 200,
             [`GET /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id} response connector id`]: (r) => r.json().destination_connector.id === csvDstConnector.id,
             [`GET /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id} response connector destination_connector_definition permalink`]: (r) => r.json().destination_connector.destination_connector_definition === constant.csvDstDefRscName,
+            [`GET /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id} response connector owner is UUID`]: (r) => helper.isValidOwner(r.json().destination_connector.connector.user),
         });
 
         check(http.request("DELETE", `${connectorPublicHost}/v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id}`), {
@@ -352,7 +358,8 @@ export function CheckUpdate() {
             [`PATCH /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id} response connector connector_definition`]: (r) => r.json().destination_connector.destination_connector_definition === constant.csvDstDefRscName,
             [`PATCH /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id} response connector description`]: (r) => r.json().destination_connector.connector.description === csvDstConnectorUpdate.connector.description,
             [`PATCH /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id} response connector tombstone`]: (r) => r.json().destination_connector.connector.tombstone === false,
-            [`PATCH /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id} response connector configuration`]: (r) => r.json().destination_connector.connector.configuration.destination_path === csvDstConnectorUpdate.connector.configuration.destination_path
+            [`PATCH /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id} response connector configuration`]: (r) => r.json().destination_connector.connector.configuration.destination_path === csvDstConnectorUpdate.connector.configuration.destination_path,
+            [`PATCH /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id} response connector owner is UUID`]: (r) => helper.isValidOwner(r.json().destination_connector.connector.user),
         });
 
         // Try to update with empty description
@@ -411,6 +418,7 @@ export function CheckLookUp() {
             [`GET /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.uid}/lookUp response status 200`]: (r) => r.status === 200,
             [`GET /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.uid}/lookUp response connector uid`]: (r) => r.json().destination_connector.uid === resCSVDst.json().destination_connector.uid,
             [`GET /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.uid}/lookUp response connector destination_connector_definition`]: (r) => r.json().destination_connector.destination_connector_definition === constant.csvDstDefRscName,
+            [`GET /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.uid}/lookUp response connector owner is UUID`]: (r) => helper.isValidOwner(r.json().destination_connector.connector.user),
         });
 
         check(http.request("DELETE", `${connectorPublicHost}/v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id}`), {

--- a/integration-test/rest-source-connector-private.js
+++ b/integration-test/rest-source-connector-private.js
@@ -10,6 +10,7 @@ import {
 } from "./const.js"
 
 import * as constant from "./const.js"
+import * as helper from "./helper.js"
 
 export function CheckList() {
 
@@ -75,17 +76,20 @@ export function CheckList() {
         check(http.request("GET", `${connectorPrivateHost}/v1alpha/admin/source-connectors?page_size=1&view=VIEW_BASIC`), {
             "GET /v1alpha/admin/source-connectors?page_size=1&view=VIEW_BASIC response status 200": (r) => r.status === 200,
             "GET /v1alpha/admin/source-connectors?page_size=1&view=VIEW_BASIC response source_connectors[0]connector.configuration is null": (r) => r.json().source_connectors[0].connector.configuration === null,
+            "GET /v1alpha/admin/source-connectors?page_size=1&view=VIEW_BASIC response source_connectors[0]connector.owner is UUID": (r) => helper.isValidOwner(r.json().source_connectors[0].connector.user),
         });
 
         check(http.request("GET", `${connectorPrivateHost}/v1alpha/admin/source-connectors?page_size=1&view=VIEW_FULL`), {
             "GET /v1alpha/admin/source-connectors?page_size=1&view=VIEW_FULL response status 200": (r) => r.status === 200,
             "GET /v1alpha/admin/source-connectors?page_size=1&view=VIEW_FULL response source_connectors[0]connector.configuration is not null": (r) => r.json().source_connectors[0].connector.configuration !== null,
-            "GET /v1alpha/admin/source-connectors?page_size=1&view=VIEW_BASIC response source_connectors[0]connector.configuration is {}": (r) => Object.keys(r.json().source_connectors[0].connector.configuration).length === 0,
+            "GET /v1alpha/admin/source-connectors?page_size=1&view=VIEW_FULL response source_connectors[0]connector.configuration is {}": (r) => Object.keys(r.json().source_connectors[0].connector.configuration).length === 0,
+            "GET /v1alpha/admin/source-connectors?page_size=1&view=VIEW_FULL response source_connectors[0]connector.owner is UUID": (r) => helper.isValidOwner(r.json().source_connectors[0].connector.user),
         });
 
         check(http.request("GET", `${connectorPrivateHost}/v1alpha/admin/source-connectors?page_size=1`), {
             "GET /v1alpha/admin/source-connectors?page_size=1 response status 200": (r) => r.status === 200,
-            "GET /v1alpha/admin/source-connectors?page_size=1 response source_connectors[0]connector.configuration is null": (r) => r.json().source_connectors[0].connector.configuration === null
+            "GET /v1alpha/admin/source-connectors?page_size=1 response source_connectors[0]connector.configuration is null": (r) => r.json().source_connectors[0].connector.configuration === null,
+            "GET /v1alpha/admin/source-connectors?page_size=1 response source_connectors[0]connector.owner is UUID": (r) => helper.isValidOwner(r.json().source_connectors[0].connector.user),
         });
 
         check(http.request("GET", `${connectorPrivateHost}/v1alpha/admin/source-connectors?page_size=${limitedRecords.json().total_size}`), {
@@ -121,6 +125,7 @@ export function CheckGet() {
             [`GET /v1alpha/admin/source-connectors/${resHTTP.json().source_connector.id} response status 200`]: (r) => r.status === 200,
             [`GET /v1alpha/admin/source-connectors/${resHTTP.json().source_connector.id} response connector id`]: (r) => r.json().source_connector.id === httpSrcConnector.id,
             [`GET /v1alpha/admin/source-connectors/${resHTTP.json().source_connector.id} response connector source_connector_definition`]: (r) => r.json().source_connector.source_connector_definition === constant.httpSrcDefRscName,
+            [`GET /v1alpha/admin/source-connectors/${resHTTP.json().source_connector.id} response connector owner is UUID`]: (r) => helper.isValidOwner(r.json().source_connector.connector.user),
         });
 
         check(http.request("DELETE", `${connectorPublicHost}/v1alpha/source-connectors/${resHTTP.json().source_connector.id}`), {
@@ -149,6 +154,7 @@ export function CheckLookUp() {
             [`GET /v1alpha/admin/source-connectors/${resHTTP.json().source_connector.uid}/lookUp response status 200`]: (r) => r.status === 200,
             [`GET /v1alpha/admin/source-connectors/${resHTTP.json().source_connector.uid}/lookUp response connector uid`]: (r) => r.json().source_connector.uid === resHTTP.json().source_connector.uid,
             [`GET /v1alpha/admin/source-connectors/${resHTTP.json().source_connector.uid}/lookUp response connector source_connector_definition`]: (r) => r.json().source_connector.source_connector_definition === constant.httpSrcDefRscName,
+            [`GET /v1alpha/admin/source-connectors/${resHTTP.json().source_connector.uid}/lookUp response connector owner is UUID`]: (r) => helper.isValidOwner(r.json().source_connector.connector.user),
         });
 
         check(http.request("DELETE", `${connectorPublicHost}/v1alpha/source-connectors/${resHTTP.json().source_connector.id}`), {

--- a/integration-test/rest-source-connector-public.js
+++ b/integration-test/rest-source-connector-public.js
@@ -38,7 +38,8 @@ export function CheckCreate() {
             "POST /v1alpha/source-connectors response status for creating HTTP source connector 201": (r) => r.status === 201,
             "POST /v1alpha/source-connectors response connector name": (r) => r.json().source_connector.name == `source-connectors/${httpSrcConnector.id}`,
             "POST /v1alpha/source-connectors response connector uid": (r) => helper.isUUID(r.json().source_connector.uid),
-            "POST /v1alpha/source-connectors response connector source_connector_definition": (r) => r.json().source_connector.source_connector_definition === constant.httpSrcDefRscName
+            "POST /v1alpha/source-connectors response connector source_connector_definition": (r) => r.json().source_connector.source_connector_definition === constant.httpSrcDefRscName,
+            "POST /v1alpha/source-connectors response connector owner is UUID": (r) => helper.isValidOwner(r.json().source_connector.connector.user),
         });
 
         check(http.request(
@@ -138,17 +139,20 @@ export function CheckList() {
         check(http.request("GET", `${connectorPublicHost}/v1alpha/source-connectors?page_size=1&view=VIEW_BASIC`), {
             "GET /v1alpha/source-connectors?page_size=1&view=VIEW_BASIC response status 200": (r) => r.status === 200,
             "GET /v1alpha/source-connectors?page_size=1&view=VIEW_BASIC response source_connectors[0]connector.configuration is null": (r) => r.json().source_connectors[0].connector.configuration === null,
+            "GET /v1alpha/source-connectors?page_size=1&view=VIEW_BASIC response source_connectors[0]connector.owner is UUID": (r) => helper.isValidOwner(r.json().source_connectors[0].connector.user),
         });
 
         check(http.request("GET", `${connectorPublicHost}/v1alpha/source-connectors?page_size=1&view=VIEW_FULL`), {
             "GET /v1alpha/source-connectors?page_size=1&view=VIEW_FULL response status 200": (r) => r.status === 200,
             "GET /v1alpha/source-connectors?page_size=1&view=VIEW_FULL response source_connectors[0]connector.configuration is not null": (r) => r.json().source_connectors[0].connector.configuration !== null,
-            "GET /v1alpha/source-connectors?page_size=1&view=VIEW_BASIC response source_connectors[0]connector.configuration is {}": (r) => Object.keys(r.json().source_connectors[0].connector.configuration).length === 0,
+            "GET /v1alpha/source-connectors?page_size=1&view=VIEW_FULL response source_connectors[0]connector.configuration is {}": (r) => Object.keys(r.json().source_connectors[0].connector.configuration).length === 0,
+            "GET /v1alpha/source-connectors?page_size=1&view=VIEW_FULL response source_connectors[0]connector.owner is UUID": (r) => helper.isValidOwner(r.json().source_connectors[0].connector.user),
         });
 
         check(http.request("GET", `${connectorPublicHost}/v1alpha/source-connectors?page_size=1`), {
             "GET /v1alpha/source-connectors?page_size=1 response status 200": (r) => r.status === 200,
-            "GET /v1alpha/source-connectors?page_size=1 response source_connectors[0]connector.configuration is null": (r) => r.json().source_connectors[0].connector.configuration === null
+            "GET /v1alpha/source-connectors?page_size=1 response source_connectors[0]connector.configuration is null": (r) => r.json().source_connectors[0].connector.configuration === null,
+            "GET /v1alpha/source-connectors?page_size=1&view=VIEW_BASIC response source_connectors[0]connector.owner is UUID": (r) => helper.isValidOwner(r.json().source_connectors[0].connector.user),
         });
 
         check(http.request("GET", `${connectorPublicHost}/v1alpha/source-connectors?page_size=${limitedRecords.json().total_size}`), {
@@ -184,6 +188,7 @@ export function CheckGet() {
             [`GET /v1alpha/source-connectors/${resHTTP.json().source_connector.id} response status 200`]: (r) => r.status === 200,
             [`GET /v1alpha/source-connectors/${resHTTP.json().source_connector.id} response connector id`]: (r) => r.json().source_connector.id === httpSrcConnector.id,
             [`GET /v1alpha/source-connectors/${resHTTP.json().source_connector.id} response connector source_connector_definition`]: (r) => r.json().source_connector.source_connector_definition === constant.httpSrcDefRscName,
+            [`GET /v1alpha/source-connectors/${resHTTP.json().source_connector.id} response connector owner is UUID`]: (r) => helper.isValidOwner(r.json().source_connector.connector.user),
         });
 
         check(http.request("DELETE", `${connectorPublicHost}/v1alpha/source-connectors/${resHTTP.json().source_connector.id}`), {
@@ -260,7 +265,7 @@ export function CheckDelete() {
             "model_definition": "model-definitions/github",
             "configuration": {
                 "repository": "instill-ai/model-dummy-cls",
-                "tag": "v1.0-cpu"
+                "tag": "v1.0"
             },
         }), constant.params)
         check(createClsModelRes, {
@@ -373,6 +378,7 @@ export function CheckLookUp() {
             [`GET /v1alpha/source-connectors/${resHTTP.json().source_connector.uid}/lookUp response status 200`]: (r) => r.status === 200,
             [`GET /v1alpha/source-connectors/${resHTTP.json().source_connector.uid}/lookUp response connector uid`]: (r) => r.json().source_connector.uid === resHTTP.json().source_connector.uid,
             [`GET /v1alpha/source-connectors/${resHTTP.json().source_connector.uid}/lookUp response connector source_connector_definition`]: (r) => r.json().source_connector.source_connector_definition === constant.httpSrcDefRscName,
+            [`GET /v1alpha/source-connectors/${resHTTP.json().source_connector.uid}/lookUp response connector owner is UUID`]: (r) => helper.isValidOwner(r.json().source_connector.connector.user),
         });
 
         check(http.request("DELETE", `${connectorPublicHost}/v1alpha/source-connectors/${resHTTP.json().source_connector.id}`), {

--- a/pkg/handler/publicHandler.go
+++ b/pkg/handler/publicHandler.go
@@ -476,7 +476,7 @@ func (h *PublicHandler) createConnector(ctx context.Context, req interface{}) (r
 	pbConnector := DBToPBConnector(
 		dbConnector,
 		connType,
-		owner.GetName(),
+		service.GenOwnerPermalink(owner),
 		connDefRscName)
 
 	switch v := resp.(type) {
@@ -888,7 +888,7 @@ func (h *PublicHandler) updateConnector(ctx context.Context, req interface{}) (r
 	pbConnector := DBToPBConnector(
 		dbConnector,
 		connType,
-		owner.GetName(),
+		service.GenOwnerPermalink(owner),
 		connDefRscName)
 
 	switch v := resp.(type) {

--- a/pkg/service/utils.go
+++ b/pkg/service/utils.go
@@ -1,0 +1,7 @@
+package service
+
+import mgmtPB "github.com/instill-ai/protogen-go/vdp/mgmt/v1alpha"
+
+func GenOwnerPermalink(owner *mgmtPB.User) string {
+	return "users/" + owner.GetUid()
+}


### PR DESCRIPTION
Because

- The user ID can be changed now (in Instill Cloud), so using the owner ID is not reliable

This commit

- refactor owner of a connector to use the UUID, not the ID
