### PR TITLE
refactor: update custom matcher

### DIFF
--- a/pkg/middleware/misc.go
+++ b/pkg/middleware/misc.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/instill-ai/connector-backend/pkg/constant"
 	"github.com/instill-ai/connector-backend/pkg/logger"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
@@ -140,7 +141,9 @@ func CustomMatcher(key string) (string, bool) {
 	}
 
 	switch key {
-	case "owner":
+	case "request-id":
+		return key, true
+	case constant.HeaderOwnerIDKey:
 		return key, true
 	default:
 		return runtime.DefaultHeaderMatcher(key)


### PR DESCRIPTION
Because

- we want to pass headers "owner-id" and "request-id" to the backend

This commit

- update custom header
