### PR TITLE
chore: support jwt-sub propagation

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -340,7 +340,7 @@ func (s *service) DeleteConnector(id string, owner *mgmtPB.User, connectorType d
 		filter = fmt.Sprintf("recipe.destination:\"%s\"", dbConnector.UID)
 	}
 
-	pipeResp, err := s.pipelinePublicServiceClient.ListPipelines(context.Background(), &pipelinePB.ListPipelinesRequest{
+	pipeResp, err := s.pipelinePublicServiceClient.ListPipelines(InjectOwnerToContext(context.Background(), owner), &pipelinePB.ListPipelinesRequest{
 		Filter: &filter,
 	})
 	if err != nil {

--- a/pkg/service/utils.go
+++ b/pkg/service/utils.go
@@ -1,7 +1,17 @@
 package service
 
-import mgmtPB "github.com/instill-ai/protogen-go/vdp/mgmt/v1alpha"
+import (
+	"context"
+
+	mgmtPB "github.com/instill-ai/protogen-go/vdp/mgmt/v1alpha"
+	"google.golang.org/grpc/metadata"
+)
 
 func GenOwnerPermalink(owner *mgmtPB.User) string {
 	return "users/" + owner.GetUid()
+}
+
+func InjectOwnerToContext(ctx context.Context, owner *mgmtPB.User) context.Context {
+	ctx = metadata.AppendToOutgoingContext(ctx, "Jwt-Sub", owner.GetUid())
+	return ctx
 }


### PR DESCRIPTION
Because

- We need to check jwt permission and also propagation it to other backend service

This commit

- support jwt-sub propagation
