### PR TITLE
chore: return 404 for non-exist user and 401 for non-existent headers

### DIFF
--- a/integration-test/grpc-destination-connector-public-with-jwt.js
+++ b/integration-test/grpc-destination-connector-public-with-jwt.js
@@ -36,7 +36,7 @@ export function CheckCreate() {
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/CreateDestinationConnector', {
             destination_connector: httpDstConnector
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/CreateDestinationConnector HTTP response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/CreateDestinationConnector HTTP response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
         })
 
         // destination-grpc
@@ -52,7 +52,7 @@ export function CheckCreate() {
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/CreateDestinationConnector', {
             destination_connector: gRPCDstConnector
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/CreateDestinationConnector gRPC response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/CreateDestinationConnector gRPC response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
         })
 
         // destination-csv
@@ -69,7 +69,7 @@ export function CheckCreate() {
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/CreateDestinationConnector', {
             destination_connector: csvDstConnector
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/CreateDestinationConnector CSV response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/CreateDestinationConnector CSV response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
         })
 
         // destination-mysql (will end up with STATE_ERROR)
@@ -90,7 +90,7 @@ export function CheckCreate() {
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/CreateDestinationConnector', {
             destination_connector: mySQLDstConnector
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/CreateDestinationConnector MySQL response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/CreateDestinationConnector MySQL response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
         })
 
         client.close();
@@ -108,7 +108,7 @@ export function CheckList() {
 
         // Cannot list destination connector of a non-exist user
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/ListDestinationConnectors', {}, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/ListDestinationConnectors response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/ListDestinationConnectors response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
         })
 
         client.close();
@@ -154,7 +154,7 @@ export function CheckGet() {
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/GetDestinationConnector', {
             name: `destination-connectors/${resCSVDst.message.destinationConnector.id}`
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/GetDestinationConnector CSV ${resCSVDst.message.destinationConnector.id} response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/GetDestinationConnector CSV ${resCSVDst.message.destinationConnector.id} response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
         })
 
         check(client.invoke(`vdp.connector.v1alpha.ConnectorPublicService/DeleteDestinationConnector`, {
@@ -206,7 +206,7 @@ export function CheckUpdate() {
             destination_connector: csvDstConnectorUpdate,
             update_mask: "connector.description,connector.configuration",
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/UpdateDestinationConnector ${csvDstConnectorUpdate.id} response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/UpdateDestinationConnector ${csvDstConnectorUpdate.id} response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
         })
 
         check(client.invoke(`vdp.connector.v1alpha.ConnectorPublicService/DeleteDestinationConnector`, {
@@ -244,7 +244,7 @@ export function CheckLookUp() {
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/LookUpDestinationConnector', {
             permalink: `destination_connector/${resCSVDst.message.destinationConnector.uid}`
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/LookUpDestinationConnector CSV ${resCSVDst.message.destinationConnector.id} response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/LookUpDestinationConnector CSV ${resCSVDst.message.destinationConnector.id} response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
         })
 
         check(client.invoke(`vdp.connector.v1alpha.ConnectorPublicService/DeleteDestinationConnector`, {
@@ -282,14 +282,14 @@ export function CheckState() {
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/ConnectDestinationConnector', {
             name: `destination-connectors/${resCSVDst.message.destinationConnector.id}`
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/ConnectDestinationConnector ${resCSVDst.message.destinationConnector.id} response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/ConnectDestinationConnector ${resCSVDst.message.destinationConnector.id} response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
         })
 
         // Cannot disconnect destination connector of a non-exist user
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/DisconnectDestinationConnector', {
             name: `destination-connectors/${resCSVDst.message.destinationConnector.id}`
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/DisconnectDestinationConnector ${resCSVDst.message.destinationConnector.id} response at UNSPECIFIED StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/DisconnectDestinationConnector ${resCSVDst.message.destinationConnector.id} response at UNSPECIFIED StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
         })
 
         // Check connector state being updated in 120 secs
@@ -310,28 +310,28 @@ export function CheckState() {
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/ConnectDestinationConnector', {
             name: `destination-connectors/${resCSVDst.message.destinationConnector.id}`
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/ConnectDestinationConnector ${resCSVDst.message.destinationConnector.id} response at STATE_CONNECTED state StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/ConnectDestinationConnector ${resCSVDst.message.destinationConnector.id} response at STATE_CONNECTED state StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
         })
 
         // Cannot disconnect destination connector of a non-exist user
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/DisconnectDestinationConnector', {
             name: `destination-connectors/${resCSVDst.message.destinationConnector.id}`
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/DisconnectDestinationConnector ${resCSVDst.message.destinationConnector.id} response at STATE_CONNECTED state StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/DisconnectDestinationConnector ${resCSVDst.message.destinationConnector.id} response at STATE_CONNECTED state StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
         })
 
         // Cannot connect destination connector of a non-exist user
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/ConnectDestinationConnector', {
             name: `destination-connectors/${resCSVDst.message.destinationConnector.id}`
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/ConnectDestinationConnector ${resCSVDst.message.destinationConnector.id} response at STATE_DISCONNECTED state StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/ConnectDestinationConnector ${resCSVDst.message.destinationConnector.id} response at STATE_DISCONNECTED state StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
         })
 
         // Cannot disconnect destination connector of a non-exist user
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/DisconnectDestinationConnector', {
             name: `destination-connectors/${resCSVDst.message.destinationConnector.id}`
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/DisconnectDestinationConnector ${resCSVDst.message.destinationConnector.id} response at STATE_DISCONNECTED state StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/DisconnectDestinationConnector ${resCSVDst.message.destinationConnector.id} response at STATE_DISCONNECTED state StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
         })
 
         check(client.invoke(`vdp.connector.v1alpha.ConnectorPublicService/DeleteDestinationConnector`, {
@@ -372,7 +372,7 @@ export function CheckRename() {
             name: resCSVDst.message.destinationConnector.id,
             new_destination_connector_id: new_id
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/RenameDestinationConnector ${resCSVDst.message.destinationConnector.id} response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/RenameDestinationConnector ${resCSVDst.message.destinationConnector.id} response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
         })
 
         check(client.invoke(`vdp.connector.v1alpha.ConnectorPublicService/DeleteDestinationConnector`, {
@@ -441,7 +441,7 @@ export function CheckWrite() {
             "data_mapping_indices": ["01GB5T5ZK9W9C2VXMWWRYM8WPA"],
             "model_outputs": constant.clsModelOutputs
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/WriteDestinationConnector ${resCSVDst.message.destinationConnector.id} response (classification) StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/WriteDestinationConnector ${resCSVDst.message.destinationConnector.id} response (classification) StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
         });
 
         // Wait for 1 sec for the connector writing to the destination-csv before deleting it

--- a/integration-test/grpc-source-connector-public-with-jwt.js
+++ b/integration-test/grpc-source-connector-public-with-jwt.js
@@ -44,14 +44,14 @@ export function CheckCreate() {
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/CreateSourceConnector', {
             source_connector: httpSrcConnector
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/CreateSourceConnector create HTTP source response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/CreateSourceConnector create HTTP source response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
         })
 
         // Cannot create source connector of a non-exist user
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/CreateSourceConnector', {
             source_connector: gRPCSrcConnector
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/CreateSourceConnector create gRPC source response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/CreateSourceConnector create gRPC source response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
         })
 
         client.close();
@@ -67,7 +67,7 @@ export function CheckList() {
 
         // Cannot list source connector of a non-exist user
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/ListSourceConnectors', {}, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/ListSourceConnectors response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/ListSourceConnectors response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
         })
 
         client.close();
@@ -97,7 +97,7 @@ export function CheckGet() {
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/GetSourceConnector', {
             name: `source-connectors/${resHTTP.message.sourceConnector.id}`
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/GetSourceConnector name=source-connectors/${resHTTP.message.sourceConnector.id} response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/GetSourceConnector name=source-connectors/${resHTTP.message.sourceConnector.id} response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
         })
 
         check(client.invoke(`vdp.connector.v1alpha.ConnectorPublicService/DeleteSourceConnector`, {
@@ -138,7 +138,7 @@ export function CheckUpdate() {
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/UpdateSourceConnector', {
             source_connector: gRPCSrcConnector
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/UpdateSourceConnector ${gRPCSrcConnector.id} response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/UpdateSourceConnector ${gRPCSrcConnector.id} response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
         })
 
         check(client.invoke(`vdp.connector.v1alpha.ConnectorPublicService/DeleteSourceConnector`, {
@@ -164,14 +164,14 @@ export function CheckDelete() {
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/DeleteSourceConnector', {
             name: `source-connectors/source-http`
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/DeleteSourceConnector source-http response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/DeleteSourceConnector source-http response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
         })
 
         // Cannot delete destination connector of a non-exist user
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/DeleteDestinationConnector', {
             name: `destination-connectors/destination-http`
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/DeleteDestinationConnector destination-http response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/DeleteDestinationConnector destination-http response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
         })
 
         client.close();
@@ -202,7 +202,7 @@ export function CheckLookUp() {
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/LookUpSourceConnector', {
             permalink: `source-connectors/${resHTTP.message.sourceConnector.uid}`
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/LookUpSourceConnector permalink=source-connectors/${resHTTP.message.sourceConnector.uid} response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/LookUpSourceConnector permalink=source-connectors/${resHTTP.message.sourceConnector.uid} response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
         })
 
         check(client.invoke(`vdp.connector.v1alpha.ConnectorPublicService/DeleteSourceConnector`, {
@@ -239,14 +239,14 @@ export function CheckState() {
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/ConnectSourceConnector', {
             name: `source-connectors/${resHTTP.message.sourceConnector.id}`
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/ConnectSourceConnector ${resHTTP.message.sourceConnector.id} response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/ConnectSourceConnector ${resHTTP.message.sourceConnector.id} response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
         })
 
         // Cannot disconnect source connector of a non-exist user
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/DisconnectSourceConnector', {
             name: `source-connectors/${resHTTP.message.sourceConnector.id}`
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/DisconnectSourceConnector ${resHTTP.message.sourceConnector.id} response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/DisconnectSourceConnector ${resHTTP.message.sourceConnector.id} response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
         })
 
         check(client.invoke(`vdp.connector.v1alpha.ConnectorPublicService/DeleteSourceConnector`, {
@@ -284,7 +284,7 @@ export function CheckRename() {
             name: `source-connectors/${resHTTP.message.sourceConnector.id}`,
             new_source_connector_id: "some-id-not-http"
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/RenameSourceConnector ${resHTTP.message.sourceConnector.id} response StatusUnknown`]: (r) => r.status === grpc.StatusUnknown,
+            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/RenameSourceConnector ${resHTTP.message.sourceConnector.id} response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
         })
 
         check(client.invoke(`vdp.connector.v1alpha.ConnectorPublicService/DeleteSourceConnector`, {

--- a/integration-test/rest-destination-connector-public-with-jwt.js
+++ b/integration-test/rest-destination-connector-public-with-jwt.js
@@ -34,14 +34,14 @@ export function CheckCreate() {
         check(http.request("POST",
             `${connectorPublicHost}/v1alpha/destination-connectors`,
             JSON.stringify(httpDstConnector), constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] POST /v1alpha/destination-connectors response for creating HTTP destination status is 500`]: (r) => r.status === 500,
+            [`[with random "jwt-sub" header] POST /v1alpha/destination-connectors response for creating HTTP destination status is 404`]: (r) => r.status === 404,
         });
 
         // Cannot create grpc destination connector of a non-exist user
         check(http.request("POST",
             `${connectorPublicHost}/v1alpha/destination-connectors`,
             JSON.stringify(gRPCDstConnector), constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] POST /v1alpha/destination-connectors response for creating gRPC destination status is 500`]: (r) => r.status === 500,
+            [`[with random "jwt-sub" header] POST /v1alpha/destination-connectors response for creating gRPC destination status is 404`]: (r) => r.status === 404,
         });
     });
 
@@ -53,7 +53,7 @@ export function CheckList() {
 
         // Cannot list destination connector of a non-exist user
         check(http.request("GET", `${connectorPublicHost}/v1alpha/destination-connectors`, null, constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] GET /v1alpha/destination-connectors response status is 500`]: (r) => r.status === 500,
+            [`[with random "jwt-sub" header] GET /v1alpha/destination-connectors response status is 404`]: (r) => r.status === 404,
         });
     });
 }
@@ -88,7 +88,7 @@ export function CheckGet() {
 
         // Cannot get a destination connector of a non-exist user
         check(http.request("GET", `${connectorPublicHost}/v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id}`, null, constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] GET /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id} response status is 500`]: (r) => r.status === 500,
+            [`[with random "jwt-sub" header] GET /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id} response status is 404`]: (r) => r.status === 404,
         });
 
         check(http.request("DELETE", `${connectorPublicHost}/v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id}`), {
@@ -130,7 +130,7 @@ export function CheckUpdate() {
             "PATCH",
             `${connectorPublicHost}/v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id}`,
             JSON.stringify(csvDstConnectorUpdate), constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] PATCH /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id} response status 500`]: (r) => r.status === 500,
+            [`[with random "jwt-sub" header] PATCH /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id} response status 404`]: (r) => r.status === 404,
         });
 
         check(http.request("DELETE", `${connectorPublicHost}/v1alpha/destination-connectors/${csvDstConnector.id}`), {
@@ -157,7 +157,7 @@ export function CheckLookUp() {
 
         // Cannot look up a destination connector of a non-exist user
         check(http.request("GET", `${connectorPublicHost}/v1alpha/destination-connectors/${resCSVDst.json().destination_connector.uid}/lookUp`, null, constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] GET /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.uid}/lookUp response status 500`]: (r) => r.status === 500,
+            [`[with random "jwt-sub" header] GET /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.uid}/lookUp response status 404`]: (r) => r.status === 404,
         });
 
         check(http.request("DELETE", `${connectorPublicHost}/v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id}`), {
@@ -183,11 +183,11 @@ export function CheckState() {
             JSON.stringify(csvDstConnector), constant.params)
 
         check(http.request("POST", `${connectorPublicHost}/v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id}/disconnect`, null, constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] POST /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id}/disconnect response at UNSPECIFIED state status 500`]: (r) => r.status === 500,
+            [`[with random "jwt-sub" header] POST /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id}/disconnect response at UNSPECIFIED state status 404`]: (r) => r.status === 404,
         });
 
         check(http.request("POST", `${connectorPublicHost}/v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id}/connect`, null, constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] POST /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id}/connect response at UNSPECIFIED state status 500`]: (r) => r.status === 500,
+            [`[with random "jwt-sub" header] POST /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id}/connect response at UNSPECIFIED state status 404`]: (r) => r.status === 404,
         });
 
         check(http.request("DELETE", `${connectorPublicHost}/v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id}`), {
@@ -219,7 +219,7 @@ export function CheckRename() {
             JSON.stringify({
                 "new_destination_connector_id": `some-id-not-${resCSVDst.json().destination_connector.id}`
             }), constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] POST /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id}/rename response status 500`]: (r) => r.status === 500,
+            [`[with random "jwt-sub" header] POST /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id}/rename response status 404`]: (r) => r.status === 404,
         });
 
         check(http.request("DELETE", `${connectorPublicHost}/v1alpha/destination-connectors/${csvDstConnector.id}`), {
@@ -277,7 +277,7 @@ export function CheckWrite() {
                 "data_mapping_indices": ["01GB5T5ZK9W9C2VXMWWRYM8WPA"],
                 "model_outputs": constant.clsModelOutputs
             }), constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] POST /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id}/write response status 500 (classification)`]: (r) => r.status === 500,
+            [`[with random "jwt-sub" header] POST /v1alpha/destination-connectors/${resCSVDst.json().destination_connector.id}/write response status 404 (classification)`]: (r) => r.status === 404,
         });
 
         // Wait for 1 sec for the connector writing to the destination-csv before deleting it

--- a/integration-test/rest-source-connector-public-with-jwt.js
+++ b/integration-test/rest-source-connector-public-with-jwt.js
@@ -32,14 +32,14 @@ export function CheckCreate() {
         check(http.request("POST",
             `${connectorPublicHost}/v1alpha/source-connectors`,
             JSON.stringify(httpSrcConnector), constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] POST /v1alpha/source-connectors response status for HTTP source connector is 500`]: (r) => r.status === 500,
+            [`[with random "jwt-sub" header] POST /v1alpha/source-connectors response status for HTTP source connector is 404`]: (r) => r.status === 404,
         });
 
         // Cannot create grpc source connector of a non-exist user
         check(http.request("POST",
             `${connectorPublicHost}/v1alpha/source-connectors`,
             JSON.stringify(gRPCSrcConnector), constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] POST /v1alpha/source-connectors response status for gRPC source connector is 500`]: (r) => r.status === 500,
+            [`[with random "jwt-sub" header] POST /v1alpha/source-connectors response status for gRPC source connector is 404`]: (r) => r.status === 404,
         });
     });
 }
@@ -50,7 +50,7 @@ export function CheckList() {
 
         // Cannot list source connector of a non-exist user
         check(http.request("GET", `${connectorPublicHost}/v1alpha/source-connectors`, null, constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] GET /v1alpha/source-connectors response status is 500`]: (r) => r.status === 500,
+            [`[with random "jwt-sub" header] GET /v1alpha/source-connectors response status is 404`]: (r) => r.status === 404,
         });
     });
 }
@@ -72,7 +72,7 @@ export function CheckGet() {
 
         // Cannot get a source connector of a non-exist user
         check(http.request("GET", `${connectorPublicHost}/v1alpha/source-connectors/${resHTTP.json().source_connector.id}`, null, constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] GET /v1alpha/source-connectors/${resHTTP.json().source_connector.id} response status is 500`]: (r) => r.status === 500,
+            [`[with random "jwt-sub" header] GET /v1alpha/source-connectors/${resHTTP.json().source_connector.id} response status is 404`]: (r) => r.status === 404,
         });
 
         check(http.request("DELETE", `${connectorPublicHost}/v1alpha/source-connectors/${resHTTP.json().source_connector.id}`), {
@@ -108,7 +108,7 @@ export function CheckUpdate() {
             "PATCH",
             `${connectorPublicHost}/v1alpha/source-connectors/${gRPCSrcConnector.id}`,
             JSON.stringify(gRPCSrcConnector), constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] PATCH /v1alpha/source-connectors/${gRPCSrcConnector.id} response status for updating gRPC source connector 500`]: (r) => r.status === 500,
+            [`[with random "jwt-sub" header] PATCH /v1alpha/source-connectors/${gRPCSrcConnector.id} response status for updating gRPC source connector 404`]: (r) => r.status === 404,
         });
 
         check(http.request("DELETE", `${connectorPublicHost}/v1alpha/source-connectors/${gRPCSrcConnector.id}`), {
@@ -125,12 +125,12 @@ export function CheckDelete() {
 
         // Cannot delete source connector of a non-exist user
         check(http.request("DELETE", `${connectorPublicHost}/v1alpha/source-connectors/source-http`, null, constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] DELETE /v1alpha/source-connectors/source-http response status 500`]: (r) => r.status === 500,
+            [`[with random "jwt-sub" header] DELETE /v1alpha/source-connectors/source-http response status 404`]: (r) => r.status === 404,
         });
 
         // Cannot delete destination connector of a non-exist user
         check(http.request("DELETE", `${connectorPublicHost}/v1alpha/destination-connectors/destination-http`, null, constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] DELETE /v1alpha/destination-connectors/destination-http response status 500`]: (r) => r.status === 500,
+            [`[with random "jwt-sub" header] DELETE /v1alpha/destination-connectors/destination-http response status 404`]: (r) => r.status === 404,
         });
     });
 }
@@ -152,7 +152,7 @@ export function CheckLookUp() {
 
         // Cannot look up source connector of a non-exist user
         check(http.request("GET", `${connectorPublicHost}/v1alpha/source-connectors/${resHTTP.json().source_connector.uid}/lookUp`, null, constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] GET /v1alpha/source-connectors/${resHTTP.json().source_connector.uid}/lookUp response status 500`]: (r) => r.status === 500,
+            [`[with random "jwt-sub" header] GET /v1alpha/source-connectors/${resHTTP.json().source_connector.uid}/lookUp response status 404`]: (r) => r.status === 404,
         });
 
         check(http.request("DELETE", `${connectorPublicHost}/v1alpha/source-connectors/${resHTTP.json().source_connector.id}`), {
@@ -178,12 +178,12 @@ export function CheckState() {
 
         // Cannot connect source connector of a non-exist user
         check(http.request("POST", `${connectorPublicHost}/v1alpha/source-connectors/${resHTTP.json().source_connector.id}/connect`, null, constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] POST /v1alpha/source-connectors/${resHTTP.json().source_connector.id}/connect response status 500`]: (r) => r.status === 500,
+            [`[with random "jwt-sub" header] POST /v1alpha/source-connectors/${resHTTP.json().source_connector.id}/connect response status 404`]: (r) => r.status === 404,
         });
 
         // Cannot disconnect source connector of a non-exist user
         check(http.request("POST", `${connectorPublicHost}/v1alpha/source-connectors/${resHTTP.json().source_connector.id}/disconnect`, null, constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] POST /v1alpha/source-connectors/${resHTTP.json().source_connector.id}/disconnect response status 500`]: (r) => r.status === 500,
+            [`[with random "jwt-sub" header] POST /v1alpha/source-connectors/${resHTTP.json().source_connector.id}/disconnect response status 404`]: (r) => r.status === 404,
         });
 
         check(http.request("DELETE", `${connectorPublicHost}/v1alpha/source-connectors/${resHTTP.json().source_connector.id}`), {
@@ -213,7 +213,7 @@ export function CheckRename() {
             JSON.stringify({
                 "new_source_connector_id": "some-id-not-http"
             }), constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] POST /v1alpha/source-connectors/${resHTTP.json().source_connector.id}/rename response status 500`]: (r) => r.status === 500,
+            [`[with random "jwt-sub" header] POST /v1alpha/source-connectors/${resHTTP.json().source_connector.id}/rename response status 404`]: (r) => r.status === 404,
         });
 
         check(http.request("DELETE", `${connectorPublicHost}/v1alpha/source-connectors/${httpSrcConnector.id}`), {

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -71,7 +71,7 @@ func GetOwner(ctx context.Context, client mgmtPB.MgmtPrivateServiceClient) (*mgm
 	if headerOwnerUId != "" {
 		_, err := uuid.FromString(headerOwnerUId)
 		if err != nil {
-			return nil, status.Errorf(codes.Unauthenticated, "Unauthenticated request")
+			return nil, status.Errorf(codes.NotFound, "Not found")
 		}
 		ownerPermalink := "users/" + headerOwnerUId
 
@@ -79,7 +79,7 @@ func GetOwner(ctx context.Context, client mgmtPB.MgmtPrivateServiceClient) (*mgm
 		defer cancel()
 		resp, err := client.LookUpUserAdmin(ctx, &mgmtPB.LookUpUserAdminRequest{Permalink: ownerPermalink})
 		if err != nil {
-			return nil, fmt.Errorf("[mgmt-backend] %s", err)
+			return nil, status.Errorf(codes.NotFound, "Not found")
 		}
 
 		return resp.User, nil
@@ -87,16 +87,16 @@ func GetOwner(ctx context.Context, client mgmtPB.MgmtPrivateServiceClient) (*mgm
 
 	// Verify "owner-id" in the header if there is no "jwt-sub"
 	headerOwnerId := GetRequestSingleHeader(ctx, constant.HeaderOwnerIDKey)
-	if headerOwnerId != constant.DefaultOwnerID {
-		return nil, status.Error(codes.Unauthenticated, "Unauthenticated request")
-	} else {
-		// Get the permalink from management backend from resource name
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		resp, err := client.GetUserAdmin(ctx, &mgmtPB.GetUserAdminRequest{Name: "users/" + headerOwnerId})
-		if err != nil {
-			return nil, fmt.Errorf("[mgmt-backend] %s", err)
-		}
-		return resp.User, nil
+	if headerOwnerId == "" {
+		return nil, status.Errorf(codes.Unauthenticated, "Unauthorized")
 	}
+
+	// Get the permalink from management backend from resource name
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	resp, err := client.GetUserAdmin(ctx, &mgmtPB.GetUserAdminRequest{Name: "users/" + headerOwnerId})
+	if err != nil {
+		return nil, status.Errorf(codes.NotFound, "Not found")
+	}
+	return resp.User, nil
 }


### PR DESCRIPTION
Because

- currently, if a user does not exist in mgmt-backend, returns 500 status error

This commit

- return 404 when a user does not exist
- return 401 when both `jwt-sub` and `owner-id` does not exist in the header 
- update tests
