### PR TITLE
chore: set up connector-backend mTLS connection for Temporal

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -11,7 +11,6 @@ import (
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/env"
 	"github.com/knadh/koanf/providers/file"
-	"go.temporal.io/sdk/client"
 )
 
 // Config - Global variable to export
@@ -26,7 +25,7 @@ type AppConfig struct {
 	PipelineBackend PipelineBackendConfig `koanf:"pipelinebackend"`
 	MgmtBackend     MgmtBackendConfig     `koanf:"mgmtbackend"`
 	Controller      ControllerConfig      `koanf:"controller"`
-	UsageServer    UsageServerConfig    `koanf:"usageserver"`
+	UsageServer     UsageServerConfig     `koanf:"usageserver"`
 }
 
 // ServerConfig defines HTTP server configurations
@@ -73,7 +72,12 @@ type DatabaseConfig struct {
 
 // TemporalConfig related to Temporal
 type TemporalConfig struct {
-	ClientOptions client.Options `koanf:"clientoptions"`
+	HostPort   string
+	Namespace  string
+	Ca         string
+	Cert       string
+	Key        string
+	ServerName string
 }
 
 // MgmtBackendConfig related to mgmt-backend
@@ -105,9 +109,9 @@ type UsageServerConfig struct {
 
 // ControllerConfig related to controller
 type ControllerConfig struct {
-	Host  string `koanf:"host"`
-	PrivatePort  int    `koanf:"privateport"`
-	HTTPS struct {
+	Host        string `koanf:"host"`
+	PrivatePort int    `koanf:"privateport"`
+	HTTPS       struct {
 		Cert string `koanf:"cert"`
 		Key  string `koanf:"key"`
 	}

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -28,8 +28,12 @@ database:
     maxconnections: 10
     connlifetime: 30m # In minutes, e.g., '60m'
 temporal:
-  clientoptions:
-    hostport: temporal:7233
+  hostport: temporal:7233
+  namespace: connector-backend
+  ca:
+  cert:
+  key:
+  servername:
 pipelinebackend:
   host: pipeline-backend
   publicport: 8081

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/iancoleman/strcase v0.2.0
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230402125221-c8f1a70b6b8b
 	github.com/instill-ai/usage-client v0.2.3-alpha
-	github.com/instill-ai/x v0.2.0-alpha
+	github.com/instill-ai/x v0.3.0-alpha
 	github.com/jackc/pgx/v5 v5.2.0
 	github.com/knadh/koanf v1.5.0
 	github.com/mennanov/fieldmask-utils v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1070,8 +1070,8 @@ github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230402125221-c8f1a70b6b8b h1:
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230402125221-c8f1a70b6b8b/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
 github.com/instill-ai/usage-client v0.2.3-alpha h1:jdbCH6WJ7eUVudGtuDWaEsWmGX09ZFUnAHx+8S2MnDY=
 github.com/instill-ai/usage-client v0.2.3-alpha/go.mod h1:G0bnSyJw3ul8iNTpAGNslB18Qux0aMZF08h+CRICumw=
-github.com/instill-ai/x v0.2.0-alpha h1:8yszKP9DE8bvSRAtEpOwqhG2wwqU3olhTqhwoiLrHfc=
-github.com/instill-ai/x v0.2.0-alpha/go.mod h1:/UEx/zFyMo7so2ctBY0pzjmIoJB9Qz5Y4gvwU2FoU74=
+github.com/instill-ai/x v0.3.0-alpha h1:z9fedROOG2dVHhswBfVwU/hzHuq8/JKSUON7inF+FH8=
+github.com/instill-ai/x v0.3.0-alpha/go.mod h1:YVYjkbqc5FKatJ+jZa1S/8e4xHkQ8j9V3RYboqBpoR0=
 github.com/intel/goresctrl v0.2.0/go.mod h1:+CZdzouYFn5EsxgqAQTEzMfwKwuc0fVdMrT9FCCAVRQ=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
 github.com/j-keck/arping v1.0.2/go.mod h1:aJbELhR92bSk7tp79AWM/ftfc90EfEi2bQJrbBFOsPw=

--- a/pkg/worker/check.go
+++ b/pkg/worker/check.go
@@ -90,14 +90,16 @@ func (w *worker) CheckWorkflow(ctx workflow.Context, param *CheckWorkflowParam) 
 	controllerCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	w.controllerClient.UpdateResource(controllerCtx, &controllerPB.UpdateResourceRequest{
+	if _, err := w.controllerClient.UpdateResource(controllerCtx, &controllerPB.UpdateResourceRequest{
 		Resource: &controllerPB.Resource{
 			Name: util.ConvertConnectorToResourceName(dbConnector.ID, dbConnector.ConnectorType),
 			State: &controllerPB.Resource_ConnectorState{
 				ConnectorState: res,
 			},
 		},
-	})
+	}); err != nil {
+		return err
+	}
 
 	logger.Info("CheckWorkflow completed")
 

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -14,9 +14,6 @@ import (
 	controllerPB "github.com/instill-ai/protogen-go/vdp/controller/v1alpha"
 )
 
-// Namespace is the Temporal namespace for connector-backend
-const Namespace = "connector-backend"
-
 // TaskQueue is the Temporal task queue name for connector-backend
 const TaskQueue = "connector-backend"
 


### PR DESCRIPTION
Because

- for users who like to connect with Temporal Cloud directly, currently the only way is by mTLS auth

This commit

- enables Temporal client TLS configuration
