### PR TITLE
chore: refactor integration test mode and update test timeout

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Run integration-test
         run: |
-          make integration-test MODE=localhost
+          make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080
 
       - name: Checkout (pipeline)
         uses: actions/checkout@v3
@@ -135,7 +135,7 @@ jobs:
 
       - name: Run integration-test
         run: |
-          make integration-test MODE=localhost
+          make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080
 
       - name: Checkout (model)
         uses: actions/checkout@v3
@@ -149,7 +149,7 @@ jobs:
 
       - name: Run integration-test
         run: |
-          make integration-test MODE=localhost
+          make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080
 
       - name: Checkout (mgmt)
         uses: actions/checkout@v3
@@ -163,4 +163,4 @@ jobs:
 
       - name: Run integration-test
         run: |
-          make integration-test MODE=localhost
+          make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080

--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,12 @@ unit-test:       				## Run unit test
 
 .PHONY: integration-test
 integration-test:				## Run integration test
-	@TEST_FOLDER_ABS_PATH=${PWD} k6 run -e MODE=$(MODE) integration-test/grpc.js --no-usage-report --quiet
-	@TEST_FOLDER_ABS_PATH=${PWD} k6 run -e MODE=$(MODE) integration-test/rest.js --no-usage-report --quiet
+	@TEST_FOLDER_ABS_PATH=${PWD} k6 run \
+		-e API_GATEWAY_PROTOCOL=${API_GATEWAY_PROTOCOL} -e API_GATEWAY_HOST=${API_GATEWAY_HOST} -e API_GATEWAY_PORT=${API_GATEWAY_PORT} \
+		integration-test/grpc.js --no-usage-report --quiet
+	@TEST_FOLDER_ABS_PATH=${PWD} k6 run \
+		-e API_GATEWAY_PROTOCOL=${API_GATEWAY_PROTOCOL} -e API_GATEWAY_HOST=${API_GATEWAY_HOST} -e API_GATEWAY_PORT=${API_GATEWAY_PORT} \
+		integration-test/rest.js --no-usage-report --quiet
 
 .PHONY: integration-test-protocol
 integration-test-protocol:		## Run integration test for VDP protocol

--- a/integration-test/const.js
+++ b/integration-test/const.js
@@ -4,27 +4,28 @@ let proto
 let pHost, cHost, mHost
 let cPrivatePort, cPublicPort, pPublicPort, mPublicPort
 
-if (__ENV.MODE == "api-gateway") {
-  // api-gateway mode for accessing api-gateway directly
+if (__ENV.API_GATEWAY_HOST && !__ENV.API_GATEWAY_PORT || !__ENV.API_GATEWAY_HOST && __ENV.API_GATEWAY_PORT) {
+  fail("both API_GATEWAY_HOST and API_GATEWAY_PORT should be properly configured.")
+}
+
+export const apiGatewayMode = (__ENV.API_GATEWAY_HOST && __ENV.API_GATEWAY_PORT);
+
+if (__ENV.API_GATEWAY_PROTOCOL) {
+  if (__ENV.API_GATEWAY_PROTOCOL !== "http" && __ENV.API_GATEWAY_PROTOCOL != "https") {
+    fail("only allow `http` or `https` for API_GATEWAY_PROTOCOL")
+  }
+  proto = __ENV.API_GATEWAY_PROTOCOL
+} else {
   proto = "http"
-  pHost = cHost = mHost = "api-gateway"
+}
+
+if (apiGatewayMode) {
+  // api gateway mode
+  pHost = cHost = mHost = __ENV.API_GATEWAY_HOST
   cPrivatePort = 3082
-  pPublicPort = cPublicPort = mPublicPort = 8080
-} else if (__ENV.MODE == "localhost") {
-  // localhost mode for accessing api-gateway from localhost
-  proto = "http"
-  pHost = cHost = mHost = "localhost"
-  cPrivatePort = 3082
-  pPublicPort = cPublicPort = mPublicPort = 8080
-} else if (__ENV.MODE == "internal") {
-  // localhost mode for accessing api-gateway from internal
-  proto = "http"
-  pHost = cHost = mHost = "host.docker.internal"
-  cPrivatePort = 3082
-  pPublicPort = cPublicPort = mPublicPort = 8080
+  pPublicPort = cPublicPort = mPublicPort = __ENV.API_GATEWAY_PORT
 } else {
   // direct microservice mode
-  proto = "http"
   pHost = "pipeline-backend"
   cHost = "connector-backend"
   mHost = "model-backend"

--- a/integration-test/grpc-destination-connector-public.js
+++ b/integration-test/grpc-destination-connector-public.js
@@ -136,9 +136,9 @@ export function CheckCreate() {
             "vdp.connector.v1alpha.ConnectorPublicService/CreateDestinationConnector MySQL response destinationConnector owner is UUID": (r) => helper.isValidOwner(r.message.destinationConnector.connector.user),
         });
 
-        // Check connector state being updated in 180 secs
+        // Check connector state being updated in 360 secs
         currentTime = new Date().getTime();
-        timeoutTime = new Date().getTime() + 180000;
+        timeoutTime = new Date().getTime() + 360000;
         var pass = false
         while (timeoutTime > currentTime) {
             var res = client.invoke('vdp.connector.v1alpha.ConnectorPublicService/WatchDestinationConnector', {

--- a/integration-test/grpc.js
+++ b/integration-test/grpc.js
@@ -72,7 +72,7 @@ export default function (data) {
     client.close();
   });
 
-  if (__ENV.MODE != "api-gateway" && __ENV.MODE != "localhost" && __ENV.MODE != "internal") {
+  if (!constant.apiGatewayMode) {
     // Source connector private
     sourceConnectorPrivate.CheckList()
     sourceConnectorPrivate.CheckGet()

--- a/integration-test/rest-destination-connector-public.js
+++ b/integration-test/rest-destination-connector-public.js
@@ -125,9 +125,9 @@ export function CheckCreate() {
             "POST /v1alpha/destination-connectors response connector owner is UUID": (r) => helper.isValidOwner(r.json().destination_connector.connector.user),
         });
 
-        // Check connector state being updated in 180 secs
+        // Check connector state being updated in 360 secs
         currentTime = new Date().getTime();
-        timeoutTime = new Date().getTime() + 180000;
+        timeoutTime = new Date().getTime() + 360000;
         var pass = false
         while (timeoutTime > currentTime) {
             var res = http.request("GET", `${connectorPublicHost}/v1alpha/destination-connectors/${resDstMySQL.json().destination_connector.id}/watch`)

--- a/integration-test/rest.js
+++ b/integration-test/rest.js
@@ -3,6 +3,7 @@ import { check, group } from "k6";
 
 import { connectorPublicHost, pipelinePublicHost } from "./const.js"
 
+import * as constant from "./const.js"
 import * as sourceConnectorDefinition from './rest-source-connector-definition.js';
 import * as destinationConnectorDefinition from './rest-destination-connector-definition.js';
 import * as sourceConnectorPublic from './rest-source-connector-public.js';
@@ -53,7 +54,7 @@ export default function (data) {
   });
 
   // private API do not expose to public.
-  if (__ENV.MODE != "api-gateway" && __ENV.MODE != "localhost" && __ENV.MODE != "internal") {
+  if (!constant.apiGatewayMode) {
     // Source connectors
     sourceConnectorPrivate.CheckList()
     sourceConnectorPrivate.CheckGet()


### PR DESCRIPTION
Because

- Need to simplify the integration test mode

This commit

- Add `API_GATEWAY_HOST`, `API_GATEWAY_PORT` and `API_GATEWAY_PROTOCOL` var. to simplify the integration test setting
- Adjust test timeout
