### PR TITLE
chore: fix CheckConnectorByUID bug

### DIFF
--- a/pkg/handler/privateHandler.go
+++ b/pkg/handler/privateHandler.go
@@ -242,14 +242,11 @@ func (h *PrivateHandler) checkConnector(ctx context.Context, req interface{}) (r
 		return resp, err
 	}
 
-	owner, err := resource.GetOwner(ctx, h.service.GetMgmtPrivateServiceClient())
-
 	if err != nil {
 		return resp, err
 	}
 
-
-	wfId, err := h.service.CheckConnectorByUID(dbConnector.UID.String(), owner, dbConnDef)
+	wfId, err := h.service.CheckConnectorByUID(dbConnector.UID.String(), dbConnector.Owner, dbConnDef)
 
 	if err != nil {
 		return resp, err

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -56,7 +56,7 @@ type Service interface {
 
 	// Longrunning operation
 	GetOperation(workflowId string) (*longrunningpb.Operation, error)
-	CheckConnectorByUID(connID string, owner *mgmtPB.User, connDef *datamodel.ConnectorDefinition) (*string, error)
+	CheckConnectorByUID(connID string, ownerPermalink string, connDef *datamodel.ConnectorDefinition) (*string, error)
 
 	// Controller custom service
 	GetResourceState(uid uuid.UUID, connectorType datamodel.ConnectorType) (*connectorPB.Connector_State, error)
@@ -646,8 +646,7 @@ func (s *service) WriteDestinationConnector(id string, owner *mgmtPB.User, param
 	return nil
 }
 
-func (s *service) CheckConnectorByUID(connUID string, owner *mgmtPB.User, connDef *datamodel.ConnectorDefinition) (*string, error) {
-	ownerPermalink := GenOwnerPermalink(owner)
+func (s *service) CheckConnectorByUID(connUID string, ownerPermalink string, connDef *datamodel.ConnectorDefinition) (*string, error) {
 
 	var wfId string
 


### PR DESCRIPTION
Because

- The `checkConnector()` use wrong `owner_id`

This commit

- Fix `checkConnector()` to use right `owner_id`
