### PR TITLE
chore: execute Airbyte `PreDownloadImage()` when cmd/init

### DIFF
--- a/cmd/init/main.go
+++ b/cmd/init/main.go
@@ -1,5 +1,38 @@
 package main
 
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+
+	"github.com/instill-ai/connector-backend/config"
+	"github.com/instill-ai/connector-backend/pkg/logger"
+
+	connectorDestinationAirbyte "github.com/instill-ai/connector-destination/pkg/airbyte"
+)
+
 func main() {
-	// Note: preserve this cmd for future use
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx, span := otel.Tracer("init-tracer").Start(ctx,
+		"main",
+	)
+	defer span.End()
+	defer cancel()
+
+	logger, _ := logger.GetZapLogger(ctx)
+
+	airbyte := connectorDestinationAirbyte.Init(logger, connectorDestinationAirbyte.ConnectorOptions{
+		MountSourceVDP:     config.Config.Container.MountSource.VDP,
+		MountTargetVDP:     config.Config.Container.MountTarget.VDP,
+		MountSourceAirbyte: config.Config.Container.MountSource.Airbyte,
+		MountTargetAirbyte: config.Config.Container.MountTarget.Airbyte,
+		VDPProtocolPath:    "/etc/vdp/vdp_protocol.yaml",
+	})
+
+	err := airbyte.(*connectorDestinationAirbyte.Connector).PreDownloadImage(logger)
+
+	if err != nil {
+		panic(err)
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2
 	github.com/iancoleman/strcase v0.2.0
 	github.com/instill-ai/connector v0.0.0-20230615093707-edf8710c4ddb
-	github.com/instill-ai/connector-destination v0.0.0-20230615101827-30b3dec806b2
+	github.com/instill-ai/connector-destination v0.0.0-20230615155538-767ce2bfdb8c
 	github.com/instill-ai/connector-source v0.0.0-20230615094018-a0432abee5e8
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230615091607-d5e75c7bc0dd
 	github.com/instill-ai/usage-client v0.2.3-alpha

--- a/go.sum
+++ b/go.sum
@@ -732,8 +732,8 @@ github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/instill-ai/connector v0.0.0-20230615093707-edf8710c4ddb h1:2COcd1xqha168hbcFJW7RXoqop/T52Z2NYuToRBeoXI=
 github.com/instill-ai/connector v0.0.0-20230615093707-edf8710c4ddb/go.mod h1:njRy7QkM8b5tnDihZdpZy8tfN86Sz8a26VEMPM8sRFQ=
-github.com/instill-ai/connector-destination v0.0.0-20230615101827-30b3dec806b2 h1:PNeaxGkIdHxlclZm+hauz+hyQ1WOJbI51ZAuR4vA9t0=
-github.com/instill-ai/connector-destination v0.0.0-20230615101827-30b3dec806b2/go.mod h1:sGbQaotOPxb+x06JsOw24ejGcWZ4RACKmQ5MZwHB7l8=
+github.com/instill-ai/connector-destination v0.0.0-20230615155538-767ce2bfdb8c h1:E2jLYM4yGKgLXr6juluP8/Y05fBxBcHjGHrFC9MGmDE=
+github.com/instill-ai/connector-destination v0.0.0-20230615155538-767ce2bfdb8c/go.mod h1:sGbQaotOPxb+x06JsOw24ejGcWZ4RACKmQ5MZwHB7l8=
 github.com/instill-ai/connector-source v0.0.0-20230615094018-a0432abee5e8 h1:ncrIkAhLZp93c4R+F/8jHX25C1M4c+RyM2vpBT4gMLM=
 github.com/instill-ai/connector-source v0.0.0-20230615094018-a0432abee5e8/go.mod h1:AcZNu454dk0XNuG01R7AAGUdhw76DAqsSV+59KATPFA=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230615091607-d5e75c7bc0dd h1:Tu2JRlXKZpC5AfoZO23xf8AkDZxvxqr/Ve+Yw1GtKS8=


### PR DESCRIPTION
Because

- we need to download the Airbyte image first before serving API

This commit

- execute Airbyte `PreDownloadImage()` when cmd/init
