### PR TITLE
chore: only preDownloadImage if the image is needed

### DIFF
--- a/cmd/init/main.go
+++ b/cmd/init/main.go
@@ -2,17 +2,26 @@ package main
 
 import (
 	"context"
+	"log"
 
 	"go.opentelemetry.io/otel"
 
+	"github.com/gofrs/uuid"
 	"github.com/instill-ai/connector-backend/config"
+	"github.com/instill-ai/connector-backend/pkg/datamodel"
 	"github.com/instill-ai/connector-backend/pkg/logger"
+	"github.com/instill-ai/connector-backend/pkg/repository"
 
+	database "github.com/instill-ai/connector-backend/pkg/db"
 	connectorDestinationAirbyte "github.com/instill-ai/connector-destination/pkg/airbyte"
+	connectorPB "github.com/instill-ai/protogen-go/vdp/connector/v1alpha"
 )
 
 func main() {
 
+	if err := config.Init(); err != nil {
+		log.Fatal(err.Error())
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	ctx, span := otel.Tracer("init-tracer").Start(ctx,
 		"main",
@@ -22,6 +31,11 @@ func main() {
 
 	logger, _ := logger.GetZapLogger(ctx)
 
+	db := database.GetConnection()
+	defer database.Close(db)
+
+	repository := repository.NewRepository(db)
+
 	airbyte := connectorDestinationAirbyte.Init(logger, connectorDestinationAirbyte.ConnectorOptions{
 		MountSourceVDP:     config.Config.Container.MountSource.VDP,
 		MountTargetVDP:     config.Config.Container.MountTarget.VDP,
@@ -30,7 +44,21 @@ func main() {
 		VDPProtocolPath:    "/etc/vdp/vdp_protocol.yaml",
 	})
 
-	err := airbyte.(*connectorDestinationAirbyte.Connector).PreDownloadImage(logger)
+	conns, _, _, err := repository.ListConnectorsAdmin(ctx, datamodel.ConnectorType(connectorPB.ConnectorType_CONNECTOR_TYPE_DESTINATION), 1000, "", false)
+	if err != nil {
+		panic(err)
+	}
+
+	airbyteConnector := airbyte.(*connectorDestinationAirbyte.Connector)
+	var uids []uuid.UUID
+	for idx := range conns {
+		uid := conns[idx].ConnectorDefinitionUID
+		if airbyteConnector.HasUid(uid) {
+			uids = append(uids, uid)
+		}
+	}
+
+	err = airbyteConnector.PreDownloadImage(logger, uids)
 
 	if err != nil {
 		panic(err)

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2
 	github.com/iancoleman/strcase v0.2.0
 	github.com/instill-ai/connector v0.0.0-20230619103836-51161aed8f55
-	github.com/instill-ai/connector-destination v0.0.0-20230619105746-7a4e77337421
+	github.com/instill-ai/connector-destination v0.0.0-20230620020359-fa098f571177
 	github.com/instill-ai/connector-source v0.0.0-20230619105805-a476c83cbc9c
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230619103359-cde5e4f5e898
 	github.com/instill-ai/usage-client v0.2.3-alpha

--- a/go.sum
+++ b/go.sum
@@ -732,8 +732,8 @@ github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/instill-ai/connector v0.0.0-20230619103836-51161aed8f55 h1:L366FMxbeIRCqgE6qcEEPTfToqscXZEuOrOFRArjPJM=
 github.com/instill-ai/connector v0.0.0-20230619103836-51161aed8f55/go.mod h1:T2JBePI9hYuoQGd6lBCek6TCTPcUkBx3pNpeokywWeU=
-github.com/instill-ai/connector-destination v0.0.0-20230619105746-7a4e77337421 h1:OEFrhQ3yQoSXoQaBVrfht+BKsF59srXtnhfAjGsh4EI=
-github.com/instill-ai/connector-destination v0.0.0-20230619105746-7a4e77337421/go.mod h1:th6sK289XOoPTswMAUxyIAv5kNM0MbQw1CDzJvaEZMk=
+github.com/instill-ai/connector-destination v0.0.0-20230620020359-fa098f571177 h1:8DFru1UKr0ynan+JTYTlzb0kCGIHzIamqGmkxKnF87s=
+github.com/instill-ai/connector-destination v0.0.0-20230620020359-fa098f571177/go.mod h1:th6sK289XOoPTswMAUxyIAv5kNM0MbQw1CDzJvaEZMk=
 github.com/instill-ai/connector-source v0.0.0-20230619105805-a476c83cbc9c h1:WL7cKx+hzJXVGCyQIEsBRqoOTquD/rag3uXb2no9W5Y=
 github.com/instill-ai/connector-source v0.0.0-20230619105805-a476c83cbc9c/go.mod h1:C8piLt1F2ejanB9N5ziG2A1AUgRGrTefEafEvIN+DWI=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230619103359-cde5e4f5e898 h1:9ValC5UmT+UpWQDYrEsTkxkXgYTcQhRAZzg4EJiQoz4=


### PR DESCRIPTION
Because

- it take too long to download all Airbyte images

This commit

- only pre-download Airbyte image if the image is needed
