### PR TITLE
chore: allow unfinished connector configuration

### DIFF
--- a/integration-test/grpc-destination-connector-private.js
+++ b/integration-test/grpc-destination-connector-private.js
@@ -51,6 +51,9 @@ export function CheckList() {
             var resDstHTTP = clientPublic.invoke('vdp.connector.v1alpha.ConnectorPublicService/CreateConnector', {
                 connector: reqBody
             })
+            clientPublic.invoke('vdp.connector.v1alpha.ConnectorPublicService/ConnectConnector', {
+                name: `connectors/${resDstHTTP.message.connector.id}`
+            })
 
             check(resDstHTTP, {
                 [`vdp.connector.v1alpha.ConnectorPublicService/CreateConnector x${reqBodies.length} HTTP response StatusOK`]: (r) => r.status === grpc.StatusOK,
@@ -160,6 +163,10 @@ export function CheckLookUp() {
 
         var resCSVDst = clientPublic.invoke('vdp.connector.v1alpha.ConnectorPublicService/CreateConnector', {
             connector: csvDstConnector
+        })
+
+        clientPublic.invoke('vdp.connector.v1alpha.ConnectorPublicService/ConnectConnector', {
+            name: `connectors/${csvDstConnector.id}`
         })
 
         check(clientPrivate.invoke('vdp.connector.v1alpha.ConnectorPrivateService/LookUpConnectorAdmin', {

--- a/integration-test/grpc-destination-connector-public-with-jwt.js
+++ b/integration-test/grpc-destination-connector-public-with-jwt.js
@@ -128,6 +128,10 @@ export function CheckGet() {
             connector: csvDstConnector
         })
 
+        client.invoke('vdp.connector.v1alpha.ConnectorPublicService/ConnectConnector', {
+            name: `connectors/${csvDstConnector.id}`
+        })
+
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/WatchConnector', {
             name: `connectors/${resCSVDst.message.connector.id}`
         }), {
@@ -168,6 +172,10 @@ export function CheckUpdate() {
 
         client.invoke('vdp.connector.v1alpha.ConnectorPublicService/CreateConnector', {
             connector: csvDstConnector
+        })
+
+        client.invoke('vdp.connector.v1alpha.ConnectorPublicService/ConnectConnector', {
+            name: `connectors/${csvDstConnector.id}`
         })
 
         var csvDstConnectorUpdate = {
@@ -218,6 +226,10 @@ export function CheckLookUp() {
             connector: csvDstConnector
         })
 
+        client.invoke('vdp.connector.v1alpha.ConnectorPublicService/ConnectConnector', {
+            name: `connectors/${csvDstConnector.id}`
+        })
+
         // Cannot look up destination connector of a non-exist user
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/LookUpConnector', {
             permalink: `connector/${resCSVDst.message.connector.uid}`
@@ -252,6 +264,10 @@ export function CheckState() {
 
         var resCSVDst = client.invoke('vdp.connector.v1alpha.ConnectorPublicService/CreateConnector', {
             connector: csvDstConnector
+        })
+
+        client.invoke('vdp.connector.v1alpha.ConnectorPublicService/ConnectConnector', {
+            name: `connectors/${csvDstConnector.id}`
         })
 
         // Cannot connect destination connector of a non-exist user
@@ -331,6 +347,10 @@ export function CheckRename() {
             connector: csvDstConnector
         })
 
+        client.invoke('vdp.connector.v1alpha.ConnectorPublicService/ConnectConnector', {
+            name: `connectors/${csvDstConnector.id}`
+        })
+
         let new_id = `some-id-not-${resCSVDst.message.connector.id}`
 
         // Cannot rename destination connector of a non-exist user
@@ -373,6 +393,10 @@ export function CheckExecute() {
 
         resCSVDst = client.invoke('vdp.connector.v1alpha.ConnectorPublicService/CreateConnector', {
             connector: csvDstConnector
+        })
+
+        client.invoke('vdp.connector.v1alpha.ConnectorPublicService/ConnectConnector', {
+            name: `connectors/${csvDstConnector.id}`
         })
 
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/WatchConnector', {
@@ -419,6 +443,10 @@ export function CheckTest() {
 
         var resCSVDst = client.invoke('vdp.connector.v1alpha.ConnectorPublicService/CreateConnector', {
             connector: csvDstConnector
+        })
+
+        client.invoke('vdp.connector.v1alpha.ConnectorPublicService/ConnectConnector', {
+            name: `connectors/${csvDstConnector.id}`
         })
 
         // Cannot test destination connector of a non-exist user

--- a/integration-test/rest-destination-connector-public-with-jwt.js
+++ b/integration-test/rest-destination-connector-public-with-jwt.js
@@ -69,6 +69,9 @@ export function CheckGet() {
         var resCSVDst = http.request("POST", `${connectorPublicHost}/v1alpha/connectors`,
             JSON.stringify(csvDstConnector), constant.params)
 
+        http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${csvDstConnector.id}/connect`,
+            {}, constant.params)
+
         check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors/${resCSVDst.json().connector.id}/watch`), {
             [`GET /v1alpha/connectors/${resCSVDst.json().connector.id}/watch response connector state is STATE_CONNECTED`]: (r) => r.json().state === "STATE_CONNECTED",
         })
@@ -224,6 +227,9 @@ export function CheckExecute() {
         resCSVDst = http.request("POST", `${connectorPublicHost}/v1alpha/connectors`,
             JSON.stringify(csvDstConnector), constant.params)
 
+        http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${csvDstConnector.id}/connect`,
+            {}, constant.params)
+
         check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors/${resCSVDst.json().connector.id}/watch`), {
             [`[with random "jwt-sub" header] GET /v1alpha/connectors/${resCSVDst.json().connector.id}/watch response connector state is STATE_CONNECTED`]: (r) => r.json().state === "STATE_CONNECTED",
         })
@@ -258,6 +264,9 @@ export function CheckTest() {
 
         var resCSVDst = http.request("POST", `${connectorPublicHost}/v1alpha/connectors`,
             JSON.stringify(csvDstConnector), constant.params)
+
+        http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${csvDstConnector.id}/connect`,
+            {}, constant.params)
 
         check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors/${resCSVDst.json().connector.id}/watch`), {
             [`GET /v1alpha/connectors/${resCSVDst.json().connector.id}/watch response connector state is STATE_CONNECTED`]: (r) => r.json().state === "STATE_CONNECTED",

--- a/integration-test/rest-destination-connector-public.js
+++ b/integration-test/rest-destination-connector-public.js
@@ -75,6 +75,8 @@ export function CheckCreate() {
         check(resCSVDst, {
             "POST /v1alpha/connectors response status 201": (r) => r.status === 201,
         });
+        http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${csvDstConnector.id}/connect`,
+            {}, constant.params)
 
         check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors/${resCSVDst.json().connector.id}/watch`), {
             [`GET /v1alpha/connectors/${resCSVDst.json().connector.id}/watch response connector state is STATE_CONNECTED`]: (r) => r.json().state === "STATE_CONNECTED",
@@ -109,37 +111,38 @@ export function CheckCreate() {
             "POST /v1alpha/connectors response connector owner is UUID": (r) => helper.isValidOwner(r.json().connector.user),
         });
 
-        check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors/${resDstMySQL.json().connector.id}/watch`), {
-            [`GET /v1alpha/connectors/${resDstMySQL.json().connector.id}/watch response connector state ended up STATE_ERROR`]: (r) => r.json().state === "STATE_ERROR",
-        })
+        // TODO check when connect
+        // check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors/${resDstMySQL.json().connector.id}/watch`), {
+        //     [`GET /v1alpha/connectors/${resDstMySQL.json().connector.id}/watch response connector state ended up STATE_ERROR`]: (r) => r.json().state === "STATE_ERROR",
+        // })
 
-        // check JSON Schema failure cases
-        var jsonSchemaFailedBodyCSV = {
-            "id": randomString(10),
-            "connector_definition_name": constant.csvDstDefRscName,
-            "description": randomString(50),
-            "configuration": {} // required destination_path
-        }
+        // // check JSON Schema failure cases
+        // var jsonSchemaFailedBodyCSV = {
+        //     "id": randomString(10),
+        //     "connector_definition_name": constant.csvDstDefRscName,
+        //     "description": randomString(50),
+        //     "configuration": {} // required destination_path
+        // }
 
-        check(http.request("POST", `${connectorPublicHost}/v1alpha/connectors`, JSON.stringify(jsonSchemaFailedBodyCSV), constant.params), {
-            "POST /v1alpha/connectors response status for JSON Schema failed body 400 (destination-csv missing destination_path)": (r) => r.status === 400,
-        });
+        // check(http.request("POST", `${connectorPublicHost}/v1alpha/connectors`, JSON.stringify(jsonSchemaFailedBodyCSV), constant.params), {
+        //     "POST /v1alpha/connectors response status for JSON Schema failed body 400 (destination-csv missing destination_path)": (r) => r.status === 400,
+        // });
 
-        var jsonSchemaFailedBodyMySQL = {
-            "id": randomString(10),
-            "connector_definition_name": constant.mySQLDstDefRscName,
-            "description": randomString(50),
-            "configuration": {
-                "host": randomString(10),
-                "port": "3306",
-                "username": randomString(10),
-                "database": randomString(10),
-            } // required port integer type
-        }
+        // var jsonSchemaFailedBodyMySQL = {
+        //     "id": randomString(10),
+        //     "connector_definition_name": constant.mySQLDstDefRscName,
+        //     "description": randomString(50),
+        //     "configuration": {
+        //         "host": randomString(10),
+        //         "port": "3306",
+        //         "username": randomString(10),
+        //         "database": randomString(10),
+        //     } // required port integer type
+        // }
 
-        check(http.request("POST", `${connectorPublicHost}/v1alpha/connectors`, JSON.stringify(jsonSchemaFailedBodyMySQL), constant.params), {
-            "POST /v1alpha/connectors response status for JSON Schema failed body 400 (destination-mysql port not integer)": (r) => r.status === 400,
-        });
+        // check(http.request("POST", `${connectorPublicHost}/v1alpha/connectors`, JSON.stringify(jsonSchemaFailedBodyMySQL), constant.params), {
+        //     "POST /v1alpha/connectors response status for JSON Schema failed body 400 (destination-mysql port not integer)": (r) => r.status === 400,
+        // });
 
         // Delete test records
         check(http.request("DELETE", `${connectorPublicHost}/v1alpha/connectors/${resDstHTTP.json().connector.id}`), {
@@ -259,6 +262,9 @@ export function CheckGet() {
 
         var resCSVDst = http.request("POST", `${connectorPublicHost}/v1alpha/connectors`,
             JSON.stringify(csvDstConnector), constant.params)
+
+        http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${csvDstConnector.id}/connect`,
+            {}, constant.params)
 
         check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors/${resCSVDst.json().connector.id}`), {
             [`GET /v1alpha/connectors/${resCSVDst.json().connector.id} response status 200`]: (r) => r.status === 200,
@@ -391,6 +397,8 @@ export function CheckState() {
 
         var resCSVDst = http.request("POST", `${connectorPublicHost}/v1alpha/connectors`,
             JSON.stringify(csvDstConnector), constant.params)
+        http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${csvDstConnector.id}/connect`,
+            {}, constant.params)
 
         check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors/${resCSVDst.json().connector.id}/watch`), {
             [`GET /v1alpha/connectors/${resCSVDst.json().connector.id}/watch response connector state is STATE_CONNECTED`]: (r) => r.json().state === "STATE_CONNECTED",
@@ -472,6 +480,9 @@ export function CheckExecute() {
         resCSVDst = http.request("POST", `${connectorPublicHost}/v1alpha/connectors`,
             JSON.stringify(csvDstConnector), constant.params)
 
+        http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${csvDstConnector.id}/connect`,
+            {}, constant.params)
+
         check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors/${resCSVDst.json().connector.id}/watch`), {
             [`GET /v1alpha/connectors/${resCSVDst.json().connector.id}/watch response connector state is STATE_CONNECTED`]: (r) => r.json().state === "STATE_CONNECTED",
         })
@@ -505,6 +516,8 @@ export function CheckExecute() {
 
         resCSVDst = http.request("POST", `${connectorPublicHost}/v1alpha/connectors`,
             JSON.stringify(csvDstConnector), constant.params)
+        http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${csvDstConnector.id}/connect`,
+            {}, constant.params)
 
         check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors/${resCSVDst.json().connector.id}/watch`), {
             [`GET /v1alpha/connectors/${resCSVDst.json().connector.id}/watch response connector state is STATE_CONNECTED`]: (r) => r.json().state === "STATE_CONNECTED",
@@ -539,6 +552,8 @@ export function CheckExecute() {
 
         resCSVDst = http.request("POST", `${connectorPublicHost}/v1alpha/connectors`,
             JSON.stringify(csvDstConnector), constant.params)
+        http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${csvDstConnector.id}/connect`,
+            {}, constant.params)
 
         check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors/${resCSVDst.json().connector.id}/watch`), {
             [`GET /v1alpha/connectors/${resCSVDst.json().connector.id}/watch response connector state is STATE_CONNECTED`]: (r) => r.json().state === "STATE_CONNECTED",
@@ -572,7 +587,8 @@ export function CheckExecute() {
 
         resCSVDst = http.request("POST", `${connectorPublicHost}/v1alpha/connectors`,
             JSON.stringify(csvDstConnector), constant.params)
-
+        http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${csvDstConnector.id}/connect`,
+            {}, constant.params)
         check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors/${resCSVDst.json().connector.id}/watch`), {
             [`GET /v1alpha/connectors/${resCSVDst.json().connector.id}/watch response connector state is STATE_CONNECTED`]: (r) => r.json().state === "STATE_CONNECTED",
         })
@@ -605,6 +621,8 @@ export function CheckExecute() {
 
         resCSVDst = http.request("POST", `${connectorPublicHost}/v1alpha/connectors`,
             JSON.stringify(csvDstConnector), constant.params)
+        http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${csvDstConnector.id}/connect`,
+            {}, constant.params)
 
         check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors/${resCSVDst.json().connector.id}/watch`), {
             [`GET /v1alpha/connectors/${resCSVDst.json().connector.id}/watch response connector state is STATE_CONNECTED`]: (r) => r.json().state === "STATE_CONNECTED",
@@ -639,6 +657,9 @@ export function CheckExecute() {
         resCSVDst = http.request("POST", `${connectorPublicHost}/v1alpha/connectors`,
             JSON.stringify(csvDstConnector), constant.params)
 
+        http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${csvDstConnector.id}/connect`,
+            {}, constant.params)
+
         check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors/${resCSVDst.json().connector.id}/watch`), {
             [`GET /v1alpha/connectors/${resCSVDst.json().connector.id}/watch response connector state is STATE_CONNECTED`]: (r) => r.json().state === "STATE_CONNECTED",
         })
@@ -672,6 +693,8 @@ export function CheckExecute() {
 
         resCSVDst = http.request("POST", `${connectorPublicHost}/v1alpha/connectors`,
             JSON.stringify(csvDstConnector), constant.params)
+        http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${csvDstConnector.id}/connect`,
+            {}, constant.params)
 
         check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors/${resCSVDst.json().connector.id}/watch`), {
             [`GET /v1alpha/connectors/${resCSVDst.json().connector.id}/watch response connector state is STATE_CONNECTED`]: (r) => r.json().state === "STATE_CONNECTED",
@@ -705,6 +728,8 @@ export function CheckExecute() {
 
         resCSVDst = http.request("POST", `${connectorPublicHost}/v1alpha/connectors`,
             JSON.stringify(csvDstConnector), constant.params)
+        http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${csvDstConnector.id}/connect`,
+            {}, constant.params)
 
         check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors/${resCSVDst.json().connector.id}/watch`), {
             [`GET /v1alpha/connectors/${resCSVDst.json().connector.id}/watch response connector state is STATE_CONNECTED`]: (r) => r.json().state === "STATE_CONNECTED",
@@ -738,6 +763,8 @@ export function CheckExecute() {
 
         resCSVDst = http.request("POST", `${connectorPublicHost}/v1alpha/connectors`,
             JSON.stringify(csvDstConnector), constant.params)
+        http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${csvDstConnector.id}/connect`,
+            {}, constant.params)
 
         check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors/${resCSVDst.json().connector.id}/watch`), {
             [`GET /v1alpha/connectors/${resCSVDst.json().connector.id}/watch response connector state is STATE_CONNECTED`]: (r) => r.json().state === "STATE_CONNECTED",
@@ -771,6 +798,8 @@ export function CheckExecute() {
 
         resCSVDst = http.request("POST", `${connectorPublicHost}/v1alpha/connectors`,
             JSON.stringify(csvDstConnector), constant.params)
+        http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${csvDstConnector.id}/connect`,
+            {}, constant.params)
 
         check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors/${resCSVDst.json().connector.id}/watch`), {
             [`GET /v1alpha/connectors/${resCSVDst.json().connector.id}/watch response connector state is STATE_CONNECTED`]: (r) => r.json().state === "STATE_CONNECTED",
@@ -807,6 +836,9 @@ export function CheckTest() {
 
         var resCSVDst = http.request("POST", `${connectorPublicHost}/v1alpha/connectors`,
             JSON.stringify(csvDstConnector), constant.params)
+
+        http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${csvDstConnector.id}/connect`,
+            {}, constant.params)
 
         check(http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${resCSVDst.json().connector.id}/testConnection`), {
             [`POST /v1alpha/connectors/${resCSVDst.json().connector.id}/testConnection response status 200`]: (r) => r.status === 200,

--- a/integration-test/rest-destination-connector.js
+++ b/integration-test/rest-destination-connector.js
@@ -83,6 +83,9 @@ export function CheckCreate() {
             headers: { "Content-Type": "application/json" },
         })
 
+        http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${csvDstConnector.id}/connect`,
+            {}, constant.params)
+
         check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors/${resCSVDst.json().connector.id}/watch`), {
             [`GET /v1alpha/connectors/${resCSVDst.json().connector.id}/watch response connector state is STATE_CONNECTED`]: (r) => r.json().state === "STATE_CONNECTED",
         })
@@ -122,41 +125,43 @@ export function CheckCreate() {
             "POST /v1alpha/connectors response connector connector_definition_name": (r) => r.json().connector.connector_definition_name === constant.mySQLDstDefRscName
         });
 
-        check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors/${resDstMySQL.json().connector.id}/watch`), {
-            "POST /v1alpha/connectors MySQL destination connector ended up STATE_ERROR": (r) => r.json().state === "STATE_ERROR"
-        })
+        // todo check json schema when connect
 
-        // check JSON Schema failure cases
-        var jsonSchemaFailedBodyCSV = {
-            "id": randomString(10),
-            "connector_definition_name": constant.csvDstDefRscName,
-            "description": randomString(50),
-            "configuration": {} // required destination_path
-        }
+        // check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors/${resDstMySQL.json().connector.id}/watch`), {
+        //     "POST /v1alpha/connectors MySQL destination connector ended up STATE_ERROR": (r) => r.json().state === "STATE_ERROR"
+        // })
 
-        check(http.request("POST", `${connectorPublicHost}/v1alpha/connectors`, JSON.stringify(jsonSchemaFailedBodyCSV), {
-            headers: { "Content-Type": "application/json" },
-        }), {
-            "POST /v1alpha/connectors response status for JSON Schema failed body 400 (destination-csv missing destination_path)": (r) => r.status === 400,
-        });
+        // // check JSON Schema failure cases
+        // var jsonSchemaFailedBodyCSV = {
+        //     "id": randomString(10),
+        //     "connector_definition_name": constant.csvDstDefRscName,
+        //     "description": randomString(50),
+        //     "configuration": {} // required destination_path
+        // }
 
-        var jsonSchemaFailedBodyMySQL = {
-            "id": randomString(10),
-            "connector_definition_name": constant.mySQLDstDefRscName,
-            "description": randomString(50),
-            "configuration": {
-                "host": randomString(10),
-                "port": "3306",
-                "username": randomString(10),
-                "database": randomString(10),
-            } // required port integer type
-        }
+        // check(http.request("POST", `${connectorPublicHost}/v1alpha/connectors`, JSON.stringify(jsonSchemaFailedBodyCSV), {
+        //     headers: { "Content-Type": "application/json" },
+        // }), {
+        //     "POST /v1alpha/connectors response status for JSON Schema failed body 400 (destination-csv missing destination_path)": (r) => r.status === 400,
+        // });
 
-        check(http.request("POST", `${connectorPublicHost}/v1alpha/connectors`, JSON.stringify(jsonSchemaFailedBodyMySQL), {
-            headers: { "Content-Type": "application/json" },
-        }), {
-            "POST /v1alpha/connectors response status for JSON Schema failed body 400 (destination-mysql port not integer)": (r) => r.status === 400,
-        });
+        // var jsonSchemaFailedBodyMySQL = {
+        //     "id": randomString(10),
+        //     "connector_definition_name": constant.mySQLDstDefRscName,
+        //     "description": randomString(50),
+        //     "configuration": {
+        //         "host": randomString(10),
+        //         "port": "3306",
+        //         "username": randomString(10),
+        //         "database": randomString(10),
+        //     } // required port integer type
+        // }
+
+        // check(http.request("POST", `${connectorPublicHost}/v1alpha/connectors`, JSON.stringify(jsonSchemaFailedBodyMySQL), {
+        //     headers: { "Content-Type": "application/json" },
+        // }), {
+        //     "POST /v1alpha/connectors response status for JSON Schema failed body 400 (destination-mysql port not integer)": (r) => r.status === 400,
+        // });
 
         // Delete test records
         check(http.request("DELETE", `${connectorPublicHost}/v1alpha/connectors/${resDstHTTP.json().connector.id}`), {
@@ -513,6 +518,7 @@ export function CheckExecute() {
             JSON.stringify(csvDstConnector), {
             headers: { "Content-Type": "application/json" },
         })
+        http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${csvDstConnector.id}/connect`,{})
 
         check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors/${resCSVDst.json().connector.id}/watch`), {
             [`GET /v1alpha/connectors/${resCSVDst.json().connector.id}/watch response connector state is STATE_CONNECTED`]: (r) => r.json().state === "STATE_CONNECTED",
@@ -549,6 +555,7 @@ export function CheckExecute() {
             JSON.stringify(csvDstConnector), {
             headers: { "Content-Type": "application/json" },
         })
+        http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${csvDstConnector.id}/connect`,{})
 
         check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors/${resCSVDst.json().connector.id}/watch`), {
             [`GET /v1alpha/connectors/${resCSVDst.json().connector.id}/watch response connector state is STATE_CONNECTED`]: (r) => r.json().state === "STATE_CONNECTED",
@@ -585,6 +592,7 @@ export function CheckExecute() {
             JSON.stringify(csvDstConnector), {
             headers: { "Content-Type": "application/json" },
         })
+        http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${csvDstConnector.id}/connect`,{})
 
         check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors/${resCSVDst.json().connector.id}/watch`), {
             [`GET /v1alpha/connectors/${resCSVDst.json().connector.id}/watch response connector state is STATE_CONNECTED`]: (r) => r.json().state === "STATE_CONNECTED",
@@ -621,6 +629,7 @@ export function CheckExecute() {
             JSON.stringify(csvDstConnector), {
             headers: { "Content-Type": "application/json" },
         })
+        http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${csvDstConnector.id}/connect`,{})
 
         check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors/${resCSVDst.json().connector.id}/watch`), {
             [`GET /v1alpha/connectors/${resCSVDst.json().connector.id}/watch response connector state is STATE_CONNECTED`]: (r) => r.json().state === "STATE_CONNECTED",

--- a/integration-test/rest-source-connector-public.js
+++ b/integration-test/rest-source-connector-public.js
@@ -206,6 +206,9 @@ export function CheckUpdate() {
             "POST /v1alpha/connectors response status for creating gRPC source connector 201": (r) => r.status === 201,
         });
 
+        http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${gRPCSrcConnector.id}/connect`,
+            {}, constant.params)
+
         gRPCSrcConnector.description = randomString(20)
 
         check(http.request(


### PR DESCRIPTION
Because

- The setting of connector may be complex, so we must let use has the ability to save the unfinished connector

This commit

- When create connector, the desired state will be disconnected
- If the connector desired state is connected, then you can not update the connector
- The only exception is `[source|destination]-[grpc|http]`. They will always be connected.
