### PR TITLE
chore: implement credential masking function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0
 	github.com/iancoleman/strcase v0.2.0
-	github.com/instill-ai/connector v0.0.0-20230628152420-4adf6bedec28
+	github.com/instill-ai/connector v0.0.0-20230629151544-f181ade74915
 	github.com/instill-ai/connector-ai v0.0.0-20230629063657-c7d21692e732
 	github.com/instill-ai/connector-blockchain v0.0.0-20230628152637-a313e5eb4d34
 	github.com/instill-ai/connector-destination v0.0.0-20230628152557-6a363a7bd381

--- a/go.sum
+++ b/go.sum
@@ -729,8 +729,8 @@ github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/instill-ai/connector v0.0.0-20230628152420-4adf6bedec28 h1:jgpEZiIZC+jJ7VZgibTg6eb+58a40mNPYp3RSiPR2VQ=
-github.com/instill-ai/connector v0.0.0-20230628152420-4adf6bedec28/go.mod h1:ctro5UDPVoLV7Toi6/cOar0JpYKtabvpXWmjtrXbce4=
+github.com/instill-ai/connector v0.0.0-20230629151544-f181ade74915 h1:mqfgPz3W9zoZ60nIjSCbJBRnAolT14ZBega2zP+3M/s=
+github.com/instill-ai/connector v0.0.0-20230629151544-f181ade74915/go.mod h1:ctro5UDPVoLV7Toi6/cOar0JpYKtabvpXWmjtrXbce4=
 github.com/instill-ai/connector-ai v0.0.0-20230629063657-c7d21692e732 h1:ZUjdvzjQG6r2KxNg+5Q0W2PX3HnWVTjD3oENVwJEq7A=
 github.com/instill-ai/connector-ai v0.0.0-20230629063657-c7d21692e732/go.mod h1:oV91P4PH2XqrR1uOXYbbVFc7vJ/s6BPNuKfLHP4OIP0=
 github.com/instill-ai/connector-blockchain v0.0.0-20230628152637-a313e5eb4d34 h1:CMWXoHzdOBgKVuubdyMGZBxm819b6d5PAgSpnV40EFA=

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -17,6 +17,8 @@ import (
 	connectorBase "github.com/instill-ai/connector/pkg/base"
 )
 
+const credentialMaskString = "*****MASK*****"
+
 type Connector struct {
 	connectorBase.BaseConnector
 	Destination connectorBase.IConnector
@@ -104,5 +106,43 @@ func (c *Connector) CreateConnection(defUid uuid.UUID, config *structpb.Struct, 
 
 	default:
 		return nil, fmt.Errorf("no connector uid: %s", defUid)
+	}
+}
+
+func MaskCredentialFields(connector connectorBase.IConnector, defId string, config *structpb.Struct) {
+	maskCredentialFields(connector, defId, config, "")
+}
+
+func maskCredentialFields(connector connectorBase.IConnector, defId string, config *structpb.Struct, prefix string) {
+
+	for k, v := range config.GetFields() {
+		key := prefix + k
+		if connector.IsCredentialField(defId, key) {
+			config.GetFields()[k] = structpb.NewStringValue(credentialMaskString)
+		}
+		if v.GetStructValue() != nil {
+			maskCredentialFields(connector, defId, v.GetStructValue(), fmt.Sprintf("%s.", key))
+		}
+
+	}
+}
+
+func RemoveCredentialFieldsWithMaskString(connector connectorBase.IConnector, defId string, config *structpb.Struct) {
+	removeCredentialFieldsWithMaskString(connector, defId, config, "")
+}
+
+func removeCredentialFieldsWithMaskString(connector connectorBase.IConnector, defId string, config *structpb.Struct, prefix string) {
+
+	for k, v := range config.GetFields() {
+		key := prefix + k
+		if connector.IsCredentialField(defId, key) {
+			if v.GetStringValue() == credentialMaskString {
+				delete(config.GetFields(), k)
+			}
+		}
+		if v.GetStructValue() != nil {
+			removeCredentialFieldsWithMaskString(connector, defId, v.GetStructValue(), fmt.Sprintf("%s.", key))
+		}
+
 	}
 }

--- a/pkg/handler/publicHandler.go
+++ b/pkg/handler/publicHandler.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/known/structpb"
 	"gorm.io/datatypes"
 
 	fieldmask_utils "github.com/mennanov/fieldmask-utils"
@@ -444,6 +445,7 @@ func (h *PublicHandler) CreateConnector(ctx context.Context, req *connectorPB.Cr
 		service.GenOwnerPermalink(owner),
 		connDefRscName)
 
+	connector.MaskCredentialFields(h.connectors, connDefResp.ConnectorDefinition.Id, pbConnector.Configuration)
 	resp.Connector = pbConnector
 
 	if err != nil {
@@ -520,6 +522,7 @@ func (h *PublicHandler) ListConnectors(ctx context.Context, req *connectorPB.Lis
 		if !isBasicView {
 			pbConnector.ConnectorDefinition = dbConnDef
 		}
+		connector.MaskCredentialFields(h.connectors, dbConnDef.GetId(), pbConnector.Configuration)
 		pbConnectors = append(
 			pbConnectors,
 			pbConnector,
@@ -545,7 +548,10 @@ func (h *PublicHandler) ListConnectors(ctx context.Context, req *connectorPB.Lis
 }
 
 func (h *PublicHandler) GetConnector(ctx context.Context, req *connectorPB.GetConnectorRequest) (resp *connectorPB.GetConnectorResponse, err error) {
+	return h.getConnector(ctx, req, true)
+}
 
+func (h *PublicHandler) getConnector(ctx context.Context, req *connectorPB.GetConnectorRequest, credentialMask bool) (resp *connectorPB.GetConnectorResponse, err error) {
 	ctx, span := tracer.Start(ctx, "GetConnector",
 		trace.WithSpanKind(trace.SpanKindServer))
 	defer span.End()
@@ -592,6 +598,10 @@ func (h *PublicHandler) GetConnector(ctx context.Context, req *connectorPB.GetCo
 		dbConnector.Owner,
 		fmt.Sprintf("%s/%s", connDefColID, dbConnDef.GetId()),
 	)
+
+	if credentialMask {
+		connector.MaskCredentialFields(h.connectors, dbConnDef.GetId(), resp.Connector.Configuration)
+	}
 
 	if !isBasicView {
 		resp.Connector.ConnectorDefinition = dbConnDef
@@ -679,12 +689,12 @@ func (h *PublicHandler) UpdateConnector(ctx context.Context, req *connectorPB.Up
 		return resp, st.Err()
 	}
 
-	getResp, err := h.GetConnector(
+	getResp, err := h.getConnector(
 		ctx,
 		&connectorPB.GetConnectorRequest{
 			Name: req.GetConnector().GetName(),
 			View: connectorPB.View_VIEW_FULL.Enum(),
-		})
+		}, false)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return resp, err
@@ -771,12 +781,19 @@ func (h *PublicHandler) UpdateConnector(ctx context.Context, req *connectorPB.Up
 		return resp, ownerErr
 	}
 
+	configuration := &structpb.Struct{}
+	proto.Merge(configuration, pbConnectorToUpdate.Configuration)
+
 	// Only the fields mentioned in the field mask will be copied to `pbPipelineToUpdate`, other fields are left intact
 	err = fieldmask_utils.StructToStruct(mask, pbConnectorReq, pbConnectorToUpdate)
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return resp, err
 	}
+
+	connector.RemoveCredentialFieldsWithMaskString(h.connectors, dbConnDef.Id, req.Connector.Configuration)
+	proto.Merge(configuration, req.Connector.Configuration)
+	pbConnectorToUpdate.Configuration = configuration
 
 	dbConnector, err := h.service.UpdateConnector(ctx, connID, owner, PBToDBConnector(ctx, pbConnectorToUpdate, owner.GetName(), dbConnDef))
 	if err != nil {
@@ -790,6 +807,7 @@ func (h *PublicHandler) UpdateConnector(ctx context.Context, req *connectorPB.Up
 		service.GenOwnerPermalink(owner),
 		connDefRscName)
 
+	connector.MaskCredentialFields(h.connectors, dbConnDef.Id, resp.Connector.Configuration)
 	logger.Info(string(custom_otel.NewLogMessage(
 		span,
 		owner,


### PR DESCRIPTION
Because

- We don't want to return credential data in api response

This commit

- Add credential masking functions. Currently, we use a fixed string to represent the masked data as a temporary solution.
