### PR TITLE
chore: update integration test params

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Run integration-test
         run: |
-          make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080
+          make integration-test API_GATEWAY_VDP_HOST=localhost API_GATEWAY_VDP_PORT=8080
 
       - name: Checkout (pipeline)
         uses: actions/checkout@v3
@@ -135,32 +135,4 @@ jobs:
 
       - name: Run integration-test
         run: |
-          make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080
-
-      - name: Checkout (model)
-        uses: actions/checkout@v3
-        with:
-          repository: instill-ai/model-backend
-
-      - name: Load .env file
-        uses: cardinalby/export-env-action@v2
-        with:
-          envFile: .env
-
-      - name: Run integration-test
-        run: |
-          make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080
-
-      - name: Checkout (mgmt)
-        uses: actions/checkout@v3
-        with:
-          repository: instill-ai/mgmt-backend
-
-      - name: Load .env file
-        uses: cardinalby/export-env-action@v2
-        with:
-          envFile: .env
-
-      - name: Run integration-test
-        run: |
-          make integration-test API_GATEWAY_HOST=localhost API_GATEWAY_PORT=8080
+          make integration-test API_GATEWAY_VDP_HOST=localhost API_GATEWAY_VDP_PORT=8080

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ dev:							## Run dev container
 		-e DOCKER_HOST=tcp://${SOCAT_HOST}:${SOCAT_PORT} \
 		-v $(PWD):/${SERVICE_NAME} \
 		-v vdp:/vdp \
+		-v $(PWD)/../connector-ai:/connector-ai \
+		-v $(PWD)/../connector-blockchain:/connector-blockchain \
+		-v $(PWD)/../go.work:/go.work \
+		-v $(PWD)/../go.work.sum:/go.work.sum \
 		-v airbyte:/airbyte \
 		-p ${SERVICE_PORT}:${SERVICE_PORT} \
 		--network instill-network \
@@ -58,10 +62,10 @@ unit-test:       				## Run unit test
 .PHONY: integration-test
 integration-test:				## Run integration test
 	@TEST_FOLDER_ABS_PATH=${PWD} k6 run \
-		-e API_GATEWAY_PROTOCOL=${API_GATEWAY_PROTOCOL} -e API_GATEWAY_HOST=${API_GATEWAY_HOST} -e API_GATEWAY_PORT=${API_GATEWAY_PORT} \
+		-e API_GATEWAY_PROTOCOL=${API_GATEWAY_PROTOCOL} -e API_GATEWAY_VDP_HOST=${API_GATEWAY_VDP_HOST} -e API_GATEWAY_VDP_PORT=${API_GATEWAY_VDP_PORT} \
 		integration-test/grpc.js --no-usage-report --quiet
 	@TEST_FOLDER_ABS_PATH=${PWD} k6 run \
-		-e API_GATEWAY_PROTOCOL=${API_GATEWAY_PROTOCOL} -e API_GATEWAY_HOST=${API_GATEWAY_HOST} -e API_GATEWAY_PORT=${API_GATEWAY_PORT} \
+		-e API_GATEWAY_PROTOCOL=${API_GATEWAY_PROTOCOL} -e API_GATEWAY_VDP_HOST=${API_GATEWAY_VDP_HOST} -e API_GATEWAY_VDP_PORT=${API_GATEWAY_VDP_PORT} \
 		integration-test/rest.js --no-usage-report --quiet
 
 .PHONY: integration-test-protocol

--- a/integration-test/const.js
+++ b/integration-test/const.js
@@ -4,11 +4,11 @@ let proto
 let pHost, cHost, mHost
 let cPrivatePort, cPublicPort, pPublicPort, mPublicPort
 
-if (__ENV.API_GATEWAY_HOST && !__ENV.API_GATEWAY_PORT || !__ENV.API_GATEWAY_HOST && __ENV.API_GATEWAY_PORT) {
-  fail("both API_GATEWAY_HOST and API_GATEWAY_PORT should be properly configured.")
+if (__ENV.API_GATEWAY_VDP_HOST && !__ENV.API_GATEWAY_VDP_PORT || !__ENV.API_GATEWAY_VDP_HOST && __ENV.API_GATEWAY_VDP_PORT) {
+  fail("both API_GATEWAY_VDP_HOST and API_GATEWAY_VDP_PORT should be properly configured.")
 }
 
-export const apiGatewayMode = (__ENV.API_GATEWAY_HOST && __ENV.API_GATEWAY_PORT);
+export const apiGatewayMode = (__ENV.API_GATEWAY_VDP_HOST && __ENV.API_GATEWAY_VDP_PORT);
 
 if (__ENV.API_GATEWAY_PROTOCOL) {
   if (__ENV.API_GATEWAY_PROTOCOL !== "http" && __ENV.API_GATEWAY_PROTOCOL != "https") {
@@ -21,9 +21,9 @@ if (__ENV.API_GATEWAY_PROTOCOL) {
 
 if (apiGatewayMode) {
   // api gateway mode
-  pHost = cHost = __ENV.API_GATEWAY_HOST
+  pHost = cHost = __ENV.API_GATEWAY_VDP_HOST
   cPrivatePort = 3082
-  pPublicPort = cPublicPort = __ENV.API_GATEWAY_PORT
+  pPublicPort = cPublicPort = __ENV.API_GATEWAY_VDP_PORT
 
   // TODO: remove model-backend dependency
   mHost = "api-gateway-model"


### PR DESCRIPTION
Because

- Some of our test-cases may be cross projects, we need to use different apigateway endpoints

This commit

- update integration test params
