### PR TITLE
chore: refactor `source-http|grpc` to `trigger` and `destination-http|grpc` to `response`

### DIFF
--- a/cmd/migration/main.go
+++ b/cmd/migration/main.go
@@ -119,7 +119,7 @@ func main() {
 			fmt.Printf("Migration to version %d complete\n", ExpectedVersion)
 			break
 		} else {
-			if step == 3 {
+			if step == 2 {
 				err := Migrate000003()
 				if err != nil {
 					panic(err)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -26,7 +26,7 @@ database:
   host: pg-sql
   port: 5432
   name: connector
-  version: 3
+  version: 4
   timezone: Etc/UTC
   pool:
     idleconnections: 5

--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/instill-ai/connector v0.1.0-alpha
 	github.com/instill-ai/connector-ai v0.1.0-alpha.0.20230712070708-0f5e6ecec4d2
 	github.com/instill-ai/connector-blockchain v0.0.0-20230710140714-d61672cca5a5
-	github.com/instill-ai/connector-destination v0.1.0-alpha
-	github.com/instill-ai/connector-source v0.1.0-alpha
+	github.com/instill-ai/connector-destination v0.1.0-alpha.0.20230714084546-f3cda01baeab
+	github.com/instill-ai/connector-source v0.1.0-alpha.0.20230714083732-63cf490ad2ba
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230628145744-8bd74278dff2
 	github.com/instill-ai/usage-client v0.2.4-alpha
 	github.com/instill-ai/x v0.3.0-alpha

--- a/go.sum
+++ b/go.sum
@@ -735,10 +735,10 @@ github.com/instill-ai/connector-ai v0.1.0-alpha.0.20230712070708-0f5e6ecec4d2 h1
 github.com/instill-ai/connector-ai v0.1.0-alpha.0.20230712070708-0f5e6ecec4d2/go.mod h1:CKViA4vgLduDbeRBWt6RaXrrH3H8uhXPBYgKnNGAcYQ=
 github.com/instill-ai/connector-blockchain v0.0.0-20230710140714-d61672cca5a5 h1:f4vQyYd8a3/A/5E/tCF55cMpV8NoV5xZWBE7NMAqTjE=
 github.com/instill-ai/connector-blockchain v0.0.0-20230710140714-d61672cca5a5/go.mod h1:Ihg6rtYaTgYphlWU5hkVn3ryyfBgw7qONWhrFT16wi0=
-github.com/instill-ai/connector-destination v0.1.0-alpha h1:lznt6tDHLubev1Ten0l83osLOIvHAol9L4HPpGpjErE=
-github.com/instill-ai/connector-destination v0.1.0-alpha/go.mod h1:PAexFoCuvtj2Zap24QC4vWizcaWxMnvxld41Nnifyqo=
-github.com/instill-ai/connector-source v0.1.0-alpha h1:oru9u2pBtFhXcT37Bxsy71zRBzzpidEVNzvM/0sqPVQ=
-github.com/instill-ai/connector-source v0.1.0-alpha/go.mod h1:eShvlmXRnityn/rKGlVN9HHIt9mtNnRLPW3PRpfhbvE=
+github.com/instill-ai/connector-destination v0.1.0-alpha.0.20230714084546-f3cda01baeab h1:w3Tkrxfn+uDuq7SGds0G+5T3Edxky1hrx7LZumFQ6vs=
+github.com/instill-ai/connector-destination v0.1.0-alpha.0.20230714084546-f3cda01baeab/go.mod h1:PAexFoCuvtj2Zap24QC4vWizcaWxMnvxld41Nnifyqo=
+github.com/instill-ai/connector-source v0.1.0-alpha.0.20230714083732-63cf490ad2ba h1:Z6F5rGoaERvBw66DB/6Pdp9TA5CwVPzgXUYnqMMV8qg=
+github.com/instill-ai/connector-source v0.1.0-alpha.0.20230714083732-63cf490ad2ba/go.mod h1:eShvlmXRnityn/rKGlVN9HHIt9mtNnRLPW3PRpfhbvE=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230628145744-8bd74278dff2 h1:e8AG+hOq2FkIz2IRq+lEJBWKY3BhzgpmjOTHVVMBEcY=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230628145744-8bd74278dff2/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
 github.com/instill-ai/usage-client v0.2.4-alpha h1:mYXd62eZsmGKBlzwMcdEgTBgn8zlbagYUHro6+p50c8=

--- a/integration-test/const.js
+++ b/integration-test/const.js
@@ -50,17 +50,11 @@ export const modelPublicHost = `${proto}://${mHost}:${mPublicPort}`;
 export const csvDstDefRscName = "connector-definitions/airbyte-destination-csv"
 export const csvDstDefRscPermalink = "connector-definitions/8be1cf83-fde1-477f-a4ad-318d23c9f3c6"
 
-export const httpSrcDefRscName = "connector-definitions/source-http"
-export const httpSrcDefRscPermalink = "connector-definitions/f20a3c02-c70e-4e76-8566-7c13ca11d18d"
+export const srcDefRscName = "connector-definitions/trigger"
+export const srcDefRscPermalink = "connector-definitions/f20a3c02-c70e-4e76-8566-7c13ca11d18d"
 
-export const gRPCSrcDefRscName = "connector-definitions/source-grpc"
-export const gRPCSrcDefRscPermalink = "connector-definitions/82ca7d29-a35c-4222-b900-8d6878195e7a"
-
-export const httpDstDefRscName = "connector-definitions/destination-http"
-export const httpDstDefRscPermalink = "connector-definitions/909c3278-f7d1-461c-9352-87741bef11d3"
-
-export const gRPCDstDefRscName = "connector-definitions/destination-grpc"
-export const gRPCDstDefRscPermalink = "connector-definitions/c0e4a82c-9620-4a72-abd1-18586f2acccd"
+export const dstDefRscName = "connector-definitions/response"
+export const dstDefRscPermalink = "connector-definitions/909c3278-f7d1-461c-9352-87741bef11d3"
 
 export const mySQLDstDefRscName = "connector-definitions/airbyte-destination-mysql"
 export const mySQLDstDefRscPermalink = "connector-definitions/ca81ee7c-3163-4246-af40-094cc31e5e42"

--- a/integration-test/grpc-destination-connector-private.js
+++ b/integration-test/grpc-destination-connector-private.js
@@ -48,14 +48,14 @@ export function CheckList() {
 
         // Create connectors
         for (const reqBody of reqBodies) {
-            var resDstHTTP = clientPublic.invoke('vdp.connector.v1alpha.ConnectorPublicService/CreateConnector', {
+            var resDst = clientPublic.invoke('vdp.connector.v1alpha.ConnectorPublicService/CreateConnector', {
                 connector: reqBody
             })
             clientPublic.invoke('vdp.connector.v1alpha.ConnectorPublicService/ConnectConnector', {
-                name: `connectors/${resDstHTTP.message.connector.id}`
+                name: `connectors/${resDst.message.connector.id}`
             })
 
-            check(resDstHTTP, {
+            check(resDst, {
                 [`vdp.connector.v1alpha.ConnectorPublicService/CreateConnector x${reqBodies.length} HTTP response StatusOK`]: (r) => r.status === grpc.StatusOK,
             });
         }
@@ -99,7 +99,7 @@ export function CheckList() {
         }, {}), {
             [`vdp.connector.v1alpha.ConnectorPrivateService/ListConnectorsAdmin pageSize=1 view=VIEW_BASIC response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.connector.v1alpha.ConnectorPrivateService/ListConnectorsAdmin pageSize=1 view=VIEW_BASIC response connectors[0].configuration is null`]: (r) => r.message.connectors[0].configuration === null,
-            [`vdp.connector.v1alpha.ConnectorPrivateService/ListConnectorsAdmin pageSize=1 view=VIEW_BASIC response connectors[0].owner is UUID`]: (r) => helper.isValidOwner(r.message.connectors[0].user ),
+            [`vdp.connector.v1alpha.ConnectorPrivateService/ListConnectorsAdmin pageSize=1 view=VIEW_BASIC response connectors[0].owner is UUID`]: (r) => helper.isValidOwner(r.message.connectors[0].user),
         });
 
         check(clientPrivate.invoke('vdp.connector.v1alpha.ConnectorPrivateService/ListConnectorsAdmin', {
@@ -109,7 +109,7 @@ export function CheckList() {
             [`vdp.connector.v1alpha.ConnectorPrivateService/ListConnectorsAdmin pageSize=1 view=VIEW_FULL response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.connector.v1alpha.ConnectorPrivateService/ListConnectorsAdmin pageSize=1 view=VIEW_FULL response connectors[0].configuration is not null`]: (r) => r.message.connectors[0].configuration !== null,
             [`vdp.connector.v1alpha.ConnectorPrivateService/ListConnectorsAdmin pageSize=1 view=VIEW_FULL response connectors[0].connectorDefinitionDetail is not null`]: (r) => r.message.connectors[0].connectorDefinitionDetail !== null,
-            [`vdp.connector.v1alpha.ConnectorPrivateService/ListConnectorsAdmin pageSize=1 view=VIEW_FULL response connectors[0].owner is UUID`]: (r) => helper.isValidOwner(r.message.connectors[0].user ),
+            [`vdp.connector.v1alpha.ConnectorPrivateService/ListConnectorsAdmin pageSize=1 view=VIEW_FULL response connectors[0].owner is UUID`]: (r) => helper.isValidOwner(r.message.connectors[0].user),
         });
 
 
@@ -118,7 +118,7 @@ export function CheckList() {
         }, {}), {
             [`vdp.connector.v1alpha.ConnectorPrivateService/ListConnectorsAdmin pageSize=1 response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.connector.v1alpha.ConnectorPrivateService/ListConnectorsAdmin pageSize=1 response connectors[0].configuration is null`]: (r) => r.message.connectors[0].configuration === null,
-            [`vdp.connector.v1alpha.ConnectorPrivateService/ListConnectorsAdmin pageSize=1 response connectors[0].owner is UUID`]: (r) => helper.isValidOwner(r.message.connectors[0].user ),
+            [`vdp.connector.v1alpha.ConnectorPrivateService/ListConnectorsAdmin pageSize=1 response connectors[0].owner is UUID`]: (r) => helper.isValidOwner(r.message.connectors[0].user),
         });
 
         check(clientPrivate.invoke('vdp.connector.v1alpha.ConnectorPrivateService/ListConnectorsAdmin', {

--- a/integration-test/grpc-destination-connector-public-with-jwt.js
+++ b/integration-test/grpc-destination-connector-public-with-jwt.js
@@ -22,10 +22,10 @@ export function CheckCreate() {
             plaintext: true
         });
 
-        // destination-http
+        // response
         var httpDstConnector = {
-            "id": "destination-http",
-            "connector_definition_name": constant.httpDstDefRscName,
+            "id": "response",
+            "connector_definition_name": constant.dstDefRscName,
             "description": "HTTP source",
             "configuration": {},
         }
@@ -35,20 +35,6 @@ export function CheckCreate() {
             connector: httpDstConnector
         }, constant.paramsGRPCWithJwt), {
             [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/CreateConnector HTTP response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
-        })
-
-        // destination-grpc
-        var gRPCDstConnector = {
-            "id": "destination-grpc",
-            "connector_definition_name": constant.gRPCDstDefRscName,
-            "configuration": {}
-        }
-
-        // Cannot create grpc destination connector of a non-exist user
-        check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/CreateConnector', {
-            connector: gRPCDstConnector
-        }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/CreateConnector gRPC response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
         })
 
         // destination-csv

--- a/integration-test/grpc-source-connector-private.js
+++ b/integration-test/grpc-source-connector-private.js
@@ -32,14 +32,8 @@ export function CheckList() {
 
         var reqBodies = [];
         reqBodies[0] = {
-            "id": "source-http",
-            "connector_definition_name": constant.httpSrcDefRscName,
-            "configuration": {}
-        }
-
-        reqBodies[1] = {
-            "id": "source-grpc",
-            "connector_definition_name": constant.gRPCSrcDefRscName,
+            "id": "trigger",
+            "connector_definition_name": constant.srcDefRscName,
             "configuration": {}
         }
 
@@ -90,7 +84,7 @@ export function CheckList() {
         }, {}), {
             [`vdp.connector.v1alpha.ConnectorPrivateService/ListConnectorsAdmin pageSize=1 view=VIEW_BASIC response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.connector.v1alpha.ConnectorPrivateService/ListConnectorsAdmin pageSize=1 view=VIEW_BASIC response has connectors[0].configuration is null`]: (r) => r.message.connectors[0].configuration === null,
-            [`vdp.connector.v1alpha.ConnectorPrivateService/ListConnectorsAdmin pageSize=1 view=VIEW_BASIC response has connectors[0].owner is UUID`]: (r) => helper.isValidOwner(r.message.connectors[0].user ),
+            [`vdp.connector.v1alpha.ConnectorPrivateService/ListConnectorsAdmin pageSize=1 view=VIEW_BASIC response has connectors[0].owner is UUID`]: (r) => helper.isValidOwner(r.message.connectors[0].user),
         });
         check(clientPrivate.invoke('vdp.connector.v1alpha.ConnectorPrivateService/ListConnectorsAdmin', {
             pageSize: 1,
@@ -100,7 +94,7 @@ export function CheckList() {
             [`vdp.connector.v1alpha.ConnectorPrivateService/ListConnectorsAdmin pageSize=1 view=VIEW_FULL response has connectors[0].configuration is not null`]: (r) => r.message.connectors[0].configuration !== null,
             [`vdp.connector.v1alpha.ConnectorPrivateService/ListConnectorsAdmin pageSize=1 view=VIEW_FULL response has connectors[0].connectorDefinitionDetail is not null`]: (r) => r.message.connectors[0].connectorDefinitionDetail !== null,
             [`vdp.connector.v1alpha.ConnectorPrivateService/ListConnectorsAdmin pageSize=1 view=VIEW_FULL response has connectors[0].configuration is {}`]: (r) => Object.keys(r.message.connectors[0].configuration).length === 0,
-            [`vdp.connector.v1alpha.ConnectorPrivateService/ListConnectorsAdmin pageSize=1 view=VIEW_FULL response has connectors[0].owner is UUID`]: (r) => helper.isValidOwner(r.message.connectors[0].user ),
+            [`vdp.connector.v1alpha.ConnectorPrivateService/ListConnectorsAdmin pageSize=1 view=VIEW_FULL response has connectors[0].owner is UUID`]: (r) => helper.isValidOwner(r.message.connectors[0].user),
         });
 
         check(clientPrivate.invoke('vdp.connector.v1alpha.ConnectorPrivateService/ListConnectorsAdmin', {
@@ -108,7 +102,7 @@ export function CheckList() {
         }, {}), {
             [`vdp.connector.v1alpha.ConnectorPrivateService/ListConnectorsAdmin pageSize=1 response StatusOK`]: (r) => r.status === grpc.StatusOK,
             [`vdp.connector.v1alpha.ConnectorPrivateService/ListConnectorsAdmin pageSize=1 response has connectors[0].configuration is null`]: (r) => r.message.connectors[0].configuration === null,
-            [`vdp.connector.v1alpha.ConnectorPrivateService/ListConnectorsAdmin pageSize=1 response has connectors[0].owner is UUID`]: (r) => helper.isValidOwner(r.message.connectors[0].user ),
+            [`vdp.connector.v1alpha.ConnectorPrivateService/ListConnectorsAdmin pageSize=1 response has connectors[0].owner is UUID`]: (r) => helper.isValidOwner(r.message.connectors[0].user),
         });
 
         check(clientPrivate.invoke('vdp.connector.v1alpha.ConnectorPrivateService/ListConnectorsAdmin', {
@@ -143,29 +137,29 @@ export function CheckLookUp() {
             plaintext: true
         });
 
-        var httpSrcConnector = {
-            "id": "source-http",
-            "connector_definition_name": constant.httpSrcDefRscName,
+        var srcConnector = {
+            "id": "trigger",
+            "connector_definition_name": constant.srcDefRscName,
             "configuration": {}
         }
 
         var resHTTP = clientPublic.invoke('vdp.connector.v1alpha.ConnectorPublicService/CreateConnector', {
-            connector: httpSrcConnector
+            connector: srcConnector
         })
 
         check(clientPrivate.invoke('vdp.connector.v1alpha.ConnectorPrivateService/LookUpConnectorAdmin', {
             permalink: `connectors/${resHTTP.message.connector.uid}`
         }, {}), {
             [`vdp.connector.v1alpha.ConnectorPrivateService/LookUpConnectorAdmin permalink=connectors/${resHTTP.message.connector.uid} response StatusOK`]: (r) => r.status === grpc.StatusOK,
-            [`vdp.connector.v1alpha.ConnectorPrivateService/LookUpConnectorAdmin permalink=connectors/${resHTTP.message.connector.uid} response connector uid`]: (r) => r.message.connector.id === httpSrcConnector.id,
-            [`vdp.connector.v1alpha.ConnectorPrivateService/LookUpConnectorAdmin permalink=connectors/${resHTTP.message.connector.uid} response connector id`]: (r) => r.message.connector.connectorDefinitionName === constant.httpSrcDefRscName,
+            [`vdp.connector.v1alpha.ConnectorPrivateService/LookUpConnectorAdmin permalink=connectors/${resHTTP.message.connector.uid} response connector uid`]: (r) => r.message.connector.id === srcConnector.id,
+            [`vdp.connector.v1alpha.ConnectorPrivateService/LookUpConnectorAdmin permalink=connectors/${resHTTP.message.connector.uid} response connector id`]: (r) => r.message.connector.connectorDefinitionName === constant.srcDefRscName,
             [`vdp.connector.v1alpha.ConnectorPrivateService/LookUpConnectorAdmin permalink=connectors/${resHTTP.message.connector.uid} response connector owner is UUID`]: (r) => helper.isValidOwner(r.message.connector.user),
         });
 
         check(clientPublic.invoke(`vdp.connector.v1alpha.ConnectorPublicService/DeleteConnector`, {
-            name: `connectors/source-http`
+            name: `connectors/trigger`
         }), {
-            [`vdp.connector.v1alpha.ConnectorPublicService/DeleteConnector source-http response StatusOK`]: (r) => r.status === grpc.StatusOK,
+            [`vdp.connector.v1alpha.ConnectorPublicService/DeleteConnector trigger response StatusOK`]: (r) => r.status === grpc.StatusOK,
         });
 
         clientPublic.close();

--- a/integration-test/grpc-source-connector-public-with-jwt.js
+++ b/integration-test/grpc-source-connector-public-with-jwt.js
@@ -22,32 +22,18 @@ export function CheckCreate() {
             plaintext: true
         });
 
-        var httpSrcConnector = {
-            "id": "source-http",
-            "connector_definition_name": constant.httpSrcDefRscName,
+        var srcConnector = {
+            "id": "trigger",
+            "connector_definition_name": constant.srcDefRscName,
             "description": "HTTP source",
             "configuration": {},
         }
 
-        var gRPCSrcConnector = {
-            "id": "source-grpc",
-            "connector_definition_name": constant.gRPCSrcDefRscName,
-            "description": "gRPC source",
-            "configuration": {},
-        }
-
         // Cannot create source connector of a non-exist user
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/CreateConnector', {
-            connector: httpSrcConnector
+            connector: srcConnector
         }, constant.paramsGRPCWithJwt), {
             [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/CreateConnector create HTTP source response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
-        })
-
-        // Cannot create source connector of a non-exist user
-        check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/CreateConnector', {
-            connector: gRPCSrcConnector
-        }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/CreateConnector create gRPC source response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
         })
 
         client.close();
@@ -79,14 +65,14 @@ export function CheckGet() {
             plaintext: true
         });
 
-        var httpSrcConnector = {
-            "id": "source-http",
-            "connector_definition_name": constant.httpSrcDefRscName,
+        var srcConnector = {
+            "id": "trigger",
+            "connector_definition_name": constant.srcDefRscName,
             "configuration": {}
         }
 
         var resHTTP = client.invoke('vdp.connector.v1alpha.ConnectorPublicService/CreateConnector', {
-            connector: httpSrcConnector
+            connector: srcConnector
         })
 
         // Cannot get source connector of a non-exist user
@@ -114,31 +100,31 @@ export function CheckUpdate() {
             plaintext: true
         });
 
-        var gRPCSrcConnector = {
-            "id": "source-grpc",
-            "connector_definition_name": constant.gRPCSrcDefRscName,
+        var srcConnector = {
+            "id": "trigger",
+            "connector_definition_name": constant.srcDefRscName,
             "configuration": {}
         }
 
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/CreateConnector', {
-            connector: gRPCSrcConnector
+            connector: srcConnector
         }), {
             "vdp.connector.v1alpha.ConnectorPublicService/CreateConnector response CreateConnector StatusOK": (r) => r.status === grpc.StatusOK,
         });
 
-        gRPCSrcConnector.description = randomString(20)
+        srcConnector.description = randomString(20)
 
         // Cannot update source connector of a non-exist user
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/UpdateConnector', {
-            connector: gRPCSrcConnector
+            connector: srcConnector
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/UpdateConnector ${gRPCSrcConnector.id} response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
+            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/UpdateConnector ${srcConnector.id} response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
         })
 
         check(client.invoke(`vdp.connector.v1alpha.ConnectorPublicService/DeleteConnector`, {
-            name: `connectors/${gRPCSrcConnector.id}`
+            name: `connectors/${srcConnector.id}`
         }), {
-            [`vdp.connector.v1alpha.ConnectorPublicService/DeleteConnector ${gRPCSrcConnector.id} response StatusOK`]: (r) => r.status === grpc.StatusOK,
+            [`vdp.connector.v1alpha.ConnectorPublicService/DeleteConnector ${srcConnector.id} response StatusOK`]: (r) => r.status === grpc.StatusOK,
         });
 
         client.close();
@@ -156,16 +142,16 @@ export function CheckDelete() {
 
         // Cannot delete source connector of a non-exist user
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/DeleteConnector', {
-            name: `connectors/source-http`
+            name: `connectors/trigger`
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/DeleteConnector source-http response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
+            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/DeleteConnector trigger response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
         })
 
         // Cannot delete destination connector of a non-exist user
         check(client.invoke('vdp.connector.v1alpha.ConnectorPublicService/DeleteConnector', {
-            name: `connectors/destination-http`
+            name: `connectors/response`
         }, constant.paramsGRPCWithJwt), {
-            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/DeleteConnector destination-http response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
+            [`[with random "jwt-sub" header] vdp.connector.v1alpha.ConnectorPublicService/DeleteConnector response response StatusNotFound`]: (r) => r.status === grpc.StatusNotFound,
         })
 
         client.close();
@@ -180,14 +166,14 @@ export function CheckLookUp() {
             plaintext: true
         });
 
-        var httpSrcConnector = {
-            "id": "source-http",
-            "connector_definition_name": constant.httpSrcDefRscName,
+        var srcConnector = {
+            "id": "trigger",
+            "connector_definition_name": constant.srcDefRscName,
             "configuration": {}
         }
 
         var resHTTP = client.invoke('vdp.connector.v1alpha.ConnectorPublicService/CreateConnector', {
-            connector: httpSrcConnector
+            connector: srcConnector
         })
 
         // Cannot look up source connector of a non-exist user
@@ -198,9 +184,9 @@ export function CheckLookUp() {
         })
 
         check(client.invoke(`vdp.connector.v1alpha.ConnectorPublicService/DeleteConnector`, {
-            name: `connectors/source-http`
+            name: `connectors/trigger`
         }), {
-            [`vdp.connector.v1alpha.ConnectorPublicService/DeleteConnector source-http response StatusOK`]: (r) => r.status === grpc.StatusOK,
+            [`vdp.connector.v1alpha.ConnectorPublicService/DeleteConnector trigger response StatusOK`]: (r) => r.status === grpc.StatusOK,
         });
 
         client.close();
@@ -215,14 +201,14 @@ export function CheckState() {
             plaintext: true
         });
 
-        var httpSrcConnector = {
-            "id": "source-http",
-            "connector_definition_name": constant.httpSrcDefRscName,
+        var srcConnector = {
+            "id": "trigger",
+            "connector_definition_name": constant.srcDefRscName,
             "configuration": {}
         }
 
         var resHTTP = client.invoke('vdp.connector.v1alpha.ConnectorPublicService/CreateConnector', {
-            connector: httpSrcConnector
+            connector: srcConnector
         })
 
         // Cannot connect source connector of a non-exist user
@@ -240,9 +226,9 @@ export function CheckState() {
         })
 
         check(client.invoke(`vdp.connector.v1alpha.ConnectorPublicService/DeleteConnector`, {
-            name: `connectors/source-http`
+            name: `connectors/trigger`
         }), {
-            [`vdp.connector.v1alpha.ConnectorPublicService/DeleteConnector source-http response StatusOK`]: (r) => r.status === grpc.StatusOK,
+            [`vdp.connector.v1alpha.ConnectorPublicService/DeleteConnector trigger response StatusOK`]: (r) => r.status === grpc.StatusOK,
         });
 
         client.close();
@@ -257,14 +243,14 @@ export function CheckRename() {
             plaintext: true
         });
 
-        var httpSrcConnector = {
-            "id": "source-http",
-            "connector_definition_name": constant.httpSrcDefRscName,
+        var srcConnector = {
+            "id": "trigger",
+            "connector_definition_name": constant.srcDefRscName,
             "configuration": {}
         }
 
         var resHTTP = client.invoke('vdp.connector.v1alpha.ConnectorPublicService/CreateConnector', {
-            connector: httpSrcConnector
+            connector: srcConnector
         })
 
         // Cannot rename source connector of a non-exist user
@@ -276,9 +262,9 @@ export function CheckRename() {
         })
 
         check(client.invoke(`vdp.connector.v1alpha.ConnectorPublicService/DeleteConnector`, {
-            name: `connectors/source-http`
+            name: `connectors/trigger`
         }), {
-            [`vdp.connector.v1alpha.ConnectorPublicService/DeleteConnector source-http response StatusOK`]: (r) => r.status === grpc.StatusOK,
+            [`vdp.connector.v1alpha.ConnectorPublicService/DeleteConnector trigger response StatusOK`]: (r) => r.status === grpc.StatusOK,
         });
 
         client.close();
@@ -292,14 +278,14 @@ export function CheckTest() {
             plaintext: true
         });
 
-        var httpSrcConnector = {
-            "id": "source-http",
-            "connector_definition_name": constant.httpSrcDefRscName,
+        var srcConnector = {
+            "id": "trigger",
+            "connector_definition_name": constant.srcDefRscName,
             "configuration": {}
         }
 
         var resHTTP = client.invoke('vdp.connector.v1alpha.ConnectorPublicService/CreateConnector', {
-            connector: httpSrcConnector
+            connector: srcConnector
         })
 
         // Cannot test connector of a non-exist user

--- a/integration-test/rest-destination-connector-public-with-jwt.js
+++ b/integration-test/rest-destination-connector-public-with-jwt.js
@@ -11,21 +11,15 @@ export function CheckCreate() {
 
     group(`Connector API: Create destination connectors [with random "jwt-sub" header]`, () => {
 
-        // destination-http
+        // response
         var httpDstConnector = {
-            "id": "destination-http",
-            "connector_definition_name": constant.httpDstDefRscName,
+            "id": "response",
+            "connector_definition_name": constant.dstDefRscName,
             "description": "HTTP source",
             "configuration": {},
 
         }
 
-        // destination-grpc
-        var gRPCDstConnector = {
-            "id": "destination-grpc",
-            "connector_definition_name": constant.gRPCDstDefRscName,
-            "configuration": {}
-        }
 
         // Cannot create http destination connector of a non-exist user
         check(http.request("POST",
@@ -34,12 +28,6 @@ export function CheckCreate() {
             [`[with random "jwt-sub" header] POST /v1alpha/connectors response for creating HTTP destination status is 404`]: (r) => r.status === 404,
         });
 
-        // Cannot create grpc destination connector of a non-exist user
-        check(http.request("POST",
-            `${connectorPublicHost}/v1alpha/connectors`,
-            JSON.stringify(gRPCDstConnector), constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] POST /v1alpha/connectors response for creating gRPC destination status is 404`]: (r) => r.status === 404,
-        });
     });
 
 }

--- a/integration-test/rest-destination-connector-public.js
+++ b/integration-test/rest-destination-connector-public.js
@@ -11,23 +11,23 @@ export function CheckCreate() {
 
     group("Connector API: Create destination connectors", () => {
 
-        // destination-http
+        // response
         var httpDstConnector = {
-            "id": "destination-http",
-            "connector_definition_name": constant.httpDstDefRscName,
+            "id": "response",
+            "connector_definition_name": constant.dstDefRscName,
             "description": "HTTP source",
             "configuration": {},
         }
 
-        var resDstHTTP = http.request(
+        var resDst = http.request(
             "POST",
             `${connectorPublicHost}/v1alpha/connectors`,
             JSON.stringify(httpDstConnector), constant.params)
-        check(resDstHTTP, {
+        check(resDst, {
             "POST /v1alpha/connectors response status for creating HTTP destination connector 201": (r) => r.status === 201,
             "POST /v1alpha/connectors response connector name": (r) => r.json().connector.name == `connectors/${httpDstConnector.id}`,
             "POST /v1alpha/connectors response connector uid": (r) => helper.isUUID(r.json().connector.uid),
-            "POST /v1alpha/connectors response connector connector_definition_name": (r) => r.json().connector.connector_definition_name === constant.httpDstDefRscName,
+            "POST /v1alpha/connectors response connector connector_definition_name": (r) => r.json().connector.connector_definition_name === constant.dstDefRscName,
             "POST /v1alpha/connectors response connector owner is UUID": (r) => helper.isValidOwner(r.json().connector.user),
         });
 
@@ -38,28 +38,6 @@ export function CheckCreate() {
             "POST /v1alpha/connectors response duplicate HTTP destination connector status 409": (r) => r.status === 409
         });
 
-        // destination-grpc
-        var gRPCDstConnector = {
-            "id": "destination-grpc",
-            "connector_definition_name": constant.gRPCDstDefRscName,
-            "configuration": {}
-        }
-
-        var resDstGRPC = http.request(
-            "POST",
-            `${connectorPublicHost}/v1alpha/connectors`,
-            JSON.stringify(gRPCDstConnector), constant.params)
-
-        check(resDstGRPC, {
-            "POST /v1alpha/connectors response status for creating gRPC destination connector 201": (r) => r.status === 201,
-        });
-
-        check(http.request(
-            "POST",
-            `${connectorPublicHost}/v1alpha/connectors`,
-            {}, constant.params), {
-            "POST /v1alpha/connectors response status for creating empty body 400": (r) => r.status === 400,
-        });
 
         // destination-csv
         var csvDstConnector = {
@@ -145,11 +123,8 @@ export function CheckCreate() {
         // });
 
         // Delete test records
-        check(http.request("DELETE", `${connectorPublicHost}/v1alpha/connectors/${resDstHTTP.json().connector.id}`), {
-            [`DELETE /v1alpha/connectors/${resDstHTTP.json().connector.id} response status 204`]: (r) => r.status === 204,
-        });
-        check(http.request("DELETE", `${connectorPublicHost}/v1alpha/connectors/${resDstGRPC.json().connector.id}`), {
-            [`DELETE /v1alpha/connectors/${resDstGRPC.json().connector.id} response status 204`]: (r) => r.status === 204,
+        check(http.request("DELETE", `${connectorPublicHost}/v1alpha/connectors/${resDst.json().connector.id}`), {
+            [`DELETE /v1alpha/connectors/${resDst.json().connector.id} response status 204`]: (r) => r.status === 204,
         });
         check(http.request("DELETE", `${connectorPublicHost}/v1alpha/connectors/${resCSVDst.json().connector.id}`), {
             [`DELETE /v1alpha/connectors/${resCSVDst.json().connector.id} response status 204`]: (r) => r.status === 204,
@@ -218,20 +193,20 @@ export function CheckList() {
         check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors?filter=connector_type=CONNECTOR_TYPE_DESTINATION&page_size=1&view=VIEW_BASIC`), {
             "GET /v1alpha/connectors?page_size=1&view=VIEW_BASIC response status 200": (r) => r.status === 200,
             "GET /v1alpha/connectors?page_size=1&view=VIEW_BASIC response connectors[0].configuration is null": (r) => r.json().connectors[0].configuration === null,
-            "GET /v1alpha/connectors?page_size=1&view=VIEW_BASIC response connectors[0].owner is UUID": (r) => helper.isValidOwner(r.json().connectors[0].user ),
+            "GET /v1alpha/connectors?page_size=1&view=VIEW_BASIC response connectors[0].owner is UUID": (r) => helper.isValidOwner(r.json().connectors[0].user),
         });
 
         check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors?filter=connector_type=CONNECTOR_TYPE_DESTINATION&page_size=1&view=VIEW_FULL`), {
             "GET /v1alpha/connectors?page_size=1&view=VIEW_FULL response status 200": (r) => r.status === 200,
             "GET /v1alpha/connectors?page_size=1&view=VIEW_FULL response connectors[0].configuration is not null": (r) => r.json().connectors[0].configuration !== null,
             "GET /v1alpha/connectors?page_size=1&view=VIEW_FULL response connectors[0].connector_definition_detail is not null": (r) => r.json().connectors[0].connector_definition_detail !== null,
-            "GET /v1alpha/connectors?page_size=1&view=VIEW_FULL response connectors[0].owner is UUID": (r) => helper.isValidOwner(r.json().connectors[0].user ),
+            "GET /v1alpha/connectors?page_size=1&view=VIEW_FULL response connectors[0].owner is UUID": (r) => helper.isValidOwner(r.json().connectors[0].user),
         });
 
         check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors?filter=connector_type=CONNECTOR_TYPE_DESTINATION&page_size=1`), {
             "GET /v1alpha/connectors?page_size=1 response status 200": (r) => r.status === 200,
             "GET /v1alpha/connectors?page_size=1 response connectors[0].configuration is null": (r) => r.json().connectors[0].configuration === null,
-            "GET /v1alpha/connectors?page_size=1 response connectors[0].owner is UUID": (r) => helper.isValidOwner(r.json().connectors[0].user ),
+            "GET /v1alpha/connectors?page_size=1 response connectors[0].owner is UUID": (r) => helper.isValidOwner(r.json().connectors[0].user),
         });
 
         check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors?filter=connector_type=CONNECTOR_TYPE_DESTINATION&page_size=${limitedRecords.json().total_size}`), {

--- a/integration-test/rest-destination-connector.js
+++ b/integration-test/rest-destination-connector.js
@@ -11,26 +11,26 @@ export function CheckCreate() {
 
     group("Connector API: Create destination connectors", () => {
 
-        // destination-http
+        // response
         var httpDstConnector = {
-            "id": "destination-http",
-            "connector_definition_name": constant.httpDstDefRscName,
+            "id": "response",
+            "connector_definition_name": constant.dstDefRscName,
             "description": "HTTP source",
             "configuration": {},
         }
 
-        var resDstHTTP = http.request(
+        var resDst = http.request(
             "POST",
             `${connectorPublicHost}/v1alpha/connectors`,
             JSON.stringify(httpDstConnector), {
             headers: { "Content-Type": "application/json" },
         })
 
-        check(resDstHTTP, {
+        check(resDst, {
             "POST /v1alpha/connectors response status for creating HTTP destination connector 201": (r) => r.status === 201,
             "POST /v1alpha/connectors response connector name": (r) => r.json().connector.name == `connectors/${httpDstConnector.id}`,
             "POST /v1alpha/connectors response connector uid": (r) => helper.isUUID(r.json().connector.uid),
-            "POST /v1alpha/connectors response connector connector_definition_name": (r) => r.json().connector.connector_definition_name === constant.httpDstDefRscName
+            "POST /v1alpha/connectors response connector connector_definition_name": (r) => r.json().connector.connector_definition_name === constant.dstDefRscName
         });
 
         check(http.request(
@@ -40,33 +40,6 @@ export function CheckCreate() {
             headers: { "Content-Type": "application/json" },
         }), {
             "POST /v1alpha/connectors response duplicate HTTP destination connector status 409": (r) => r.status === 409
-        });
-
-        // destination-grpc
-        var gRPCDstConnector = {
-            "id": "destination-grpc",
-            "connector_definition_name": constant.gRPCDstDefRscName,
-            "configuration": {}
-        }
-
-        var resDstGRPC = http.request(
-            "POST",
-            `${connectorPublicHost}/v1alpha/connectors`,
-            JSON.stringify(gRPCDstConnector), {
-            headers: { "Content-Type": "application/json" },
-        })
-
-        check(resDstGRPC, {
-            "POST /v1alpha/connectors response status for creating gRPC destination connector 201": (r) => r.status === 201,
-        });
-
-        check(http.request(
-            "POST",
-            `${connectorPublicHost}/v1alpha/connectors`,
-            {}, {
-            headers: { "Content-Type": "application/json" },
-        }), {
-            "POST /v1alpha/connectors response status for creating empty body 400": (r) => r.status === 400,
         });
 
         // destination-csv
@@ -164,11 +137,8 @@ export function CheckCreate() {
         // });
 
         // Delete test records
-        check(http.request("DELETE", `${connectorPublicHost}/v1alpha/connectors/${resDstHTTP.json().connector.id}`), {
-            [`DELETE /v1alpha/connectors/${resDstHTTP.json().connector.id} response status 204`]: (r) => r.status === 204,
-        });
-        check(http.request("DELETE", `${connectorPublicHost}/v1alpha/connectors/${resDstGRPC.json().connector.id}`), {
-            [`DELETE /v1alpha/connectors/${resDstGRPC.json().connector.id} response status 204`]: (r) => r.status === 204,
+        check(http.request("DELETE", `${connectorPublicHost}/v1alpha/connectors/${resDst.json().connector.id}`), {
+            [`DELETE /v1alpha/connectors/${resDst.json().connector.id} response status 204`]: (r) => r.status === 204,
         });
         check(http.request("DELETE", `${connectorPublicHost}/v1alpha/connectors/${resCSVDst.json().connector.id}`), {
             [`DELETE /v1alpha/connectors/${resCSVDst.json().connector.id} response status 204`]: (r) => r.status === 204,
@@ -518,7 +488,7 @@ export function CheckExecute() {
             JSON.stringify(csvDstConnector), {
             headers: { "Content-Type": "application/json" },
         })
-        http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${csvDstConnector.id}/connect`,{})
+        http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${csvDstConnector.id}/connect`, {})
 
         check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors/${resCSVDst.json().connector.id}/watch`), {
             [`GET /v1alpha/connectors/${resCSVDst.json().connector.id}/watch response connector state is STATE_CONNECTED`]: (r) => r.json().state === "STATE_CONNECTED",
@@ -555,7 +525,7 @@ export function CheckExecute() {
             JSON.stringify(csvDstConnector), {
             headers: { "Content-Type": "application/json" },
         })
-        http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${csvDstConnector.id}/connect`,{})
+        http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${csvDstConnector.id}/connect`, {})
 
         check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors/${resCSVDst.json().connector.id}/watch`), {
             [`GET /v1alpha/connectors/${resCSVDst.json().connector.id}/watch response connector state is STATE_CONNECTED`]: (r) => r.json().state === "STATE_CONNECTED",
@@ -592,7 +562,7 @@ export function CheckExecute() {
             JSON.stringify(csvDstConnector), {
             headers: { "Content-Type": "application/json" },
         })
-        http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${csvDstConnector.id}/connect`,{})
+        http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${csvDstConnector.id}/connect`, {})
 
         check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors/${resCSVDst.json().connector.id}/watch`), {
             [`GET /v1alpha/connectors/${resCSVDst.json().connector.id}/watch response connector state is STATE_CONNECTED`]: (r) => r.json().state === "STATE_CONNECTED",
@@ -629,7 +599,7 @@ export function CheckExecute() {
             JSON.stringify(csvDstConnector), {
             headers: { "Content-Type": "application/json" },
         })
-        http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${csvDstConnector.id}/connect`,{})
+        http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${csvDstConnector.id}/connect`, {})
 
         check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors/${resCSVDst.json().connector.id}/watch`), {
             [`GET /v1alpha/connectors/${resCSVDst.json().connector.id}/watch response connector state is STATE_CONNECTED`]: (r) => r.json().state === "STATE_CONNECTED",

--- a/integration-test/rest-source-connector-private.js
+++ b/integration-test/rest-source-connector-private.js
@@ -25,15 +25,8 @@ export function CheckList() {
 
         var reqBodies = [];
         reqBodies[0] = {
-            "id": "source-http",
-            "connector_definition_name": constant.httpSrcDefRscName,
-            "configuration": {}
-
-        }
-
-        reqBodies[1] = {
-            "id": "source-grpc",
-            "connector_definition_name": constant.gRPCSrcDefRscName,
+            "id": "trigger",
+            "connector_definition_name": constant.srcDefRscName,
             "configuration": {}
 
         }
@@ -109,20 +102,20 @@ export function CheckLookUp() {
 
     group("Connector API: Look up source connectors by UID by admin", () => {
 
-        var httpSrcConnector = {
-            "id": "source-http",
-            "connector_definition_name": constant.httpSrcDefRscName,
+        var srcConnector = {
+            "id": "trigger",
+            "connector_definition_name": constant.srcDefRscName,
             "configuration": {}
 
         }
 
         var resHTTP = http.request("POST", `${connectorPublicHost}/v1alpha/connectors`,
-            JSON.stringify(httpSrcConnector), constant.params)
+            JSON.stringify(srcConnector), constant.params)
 
         check(http.request("GET", `${connectorPrivateHost}/v1alpha/admin/connectors/${resHTTP.json().connector.uid}/lookUp`), {
             [`GET /v1alpha/admin/connectors/${resHTTP.json().uid}/lookUp response status 200`]: (r) => r.status === 200,
             [`GET /v1alpha/admin/connectors/${resHTTP.json().uid}/lookUp response connector uid`]: (r) => r.json().connector.uid === resHTTP.json().connector.uid,
-            [`GET /v1alpha/admin/connectors/${resHTTP.json().uid}/lookUp response connector connector_definition_name`]: (r) => r.json().connector.connector_definition_name === constant.httpSrcDefRscName,
+            [`GET /v1alpha/admin/connectors/${resHTTP.json().uid}/lookUp response connector connector_definition_name`]: (r) => r.json().connector.connector_definition_name === constant.srcDefRscName,
             [`GET /v1alpha/admin/connectors/${resHTTP.json().uid}/lookUp response connector owner is UUID`]: (r) => helper.isValidOwner(r.json().connector.user),
         });
 

--- a/integration-test/rest-source-connector-public-with-jwt.js
+++ b/integration-test/rest-source-connector-public-with-jwt.js
@@ -11,32 +11,20 @@ export function CheckCreate() {
 
     group(`Connector API: Create source connectors [with random "jwt-sub" header]`, () => {
 
-        var httpSrcConnector = {
-            "id": "source-http",
-            "connector_definition_name": constant.httpSrcDefRscName,
+        var srcConnector = {
+            "id": "trigger",
+            "connector_definition_name": constant.srcDefRscName,
             "description": "HTTP source",
             "configuration": {},
         }
 
-        var gRPCSrcConnector = {
-            "id": "source-grpc",
-            "connector_definition_name": constant.gRPCSrcDefRscName,
-            "description": "gRPC source",
-            "configuration": {},
-        }
 
         check(http.request("POST",
             `${connectorPublicHost}/v1alpha/connectors`,
-            JSON.stringify(httpSrcConnector), constant.paramsHTTPWithJwt), {
+            JSON.stringify(srcConnector), constant.paramsHTTPWithJwt), {
             [`[with random "jwt-sub" header] POST /v1alpha/connectors response status for HTTP source connector is 404`]: (r) => r.status === 404,
         });
 
-        // Cannot create grpc source connector of a non-exist user
-        check(http.request("POST",
-            `${connectorPublicHost}/v1alpha/connectors`,
-            JSON.stringify(gRPCSrcConnector), constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] POST /v1alpha/connectors response status for gRPC source connector is 404`]: (r) => r.status === 404,
-        });
     });
 }
 
@@ -55,14 +43,14 @@ export function CheckGet() {
 
     group(`Connector API: Get source connectors by ID [with random "jwt-sub" header]`, () => {
 
-        var httpSrcConnector = {
-            "id": "source-http",
-            "connector_definition_name": constant.httpSrcDefRscName,
+        var srcConnector = {
+            "id": "trigger",
+            "connector_definition_name": constant.srcDefRscName,
             "configuration": {}
         }
 
         var resHTTP = http.request("POST", `${connectorPublicHost}/v1alpha/connectors`,
-            JSON.stringify(httpSrcConnector), constant.params)
+            JSON.stringify(srcConnector), constant.params)
 
         // Cannot get a source connector of a non-exist user
         check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors/${resHTTP.json().connector.id}`, null, constant.paramsHTTPWithJwt), {
@@ -80,31 +68,31 @@ export function CheckUpdate() {
 
     group(`Connector API: Update source connectors [with random "jwt-sub" header]`, () => {
 
-        var gRPCSrcConnector = {
-            "id": "source-grpc",
-            "connector_definition_name": constant.gRPCSrcDefRscName,
+        var srcConnector = {
+            "id": "trigger",
+            "connector_definition_name": constant.srcDefRscName,
             "configuration": {}
         }
 
         check(http.request(
             "POST",
             `${connectorPublicHost}/v1alpha/connectors`,
-            JSON.stringify(gRPCSrcConnector), constant.params), {
+            JSON.stringify(srcConnector), constant.params), {
             "POST /v1alpha/connectors response status for creating gRPC source connector 201": (r) => r.status === 201,
         });
 
-        gRPCSrcConnector.description = randomString(20)
+        srcConnector.description = randomString(20)
 
         // Cannot patch a source connector of a non-exist user
         check(http.request(
             "PATCH",
-            `${connectorPublicHost}/v1alpha/connectors/${gRPCSrcConnector.id}`,
-            JSON.stringify(gRPCSrcConnector), constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] PATCH /v1alpha/connectors/${gRPCSrcConnector.id} response status for updating gRPC source connector 404`]: (r) => r.status === 404,
+            `${connectorPublicHost}/v1alpha/connectors/${srcConnector.id}`,
+            JSON.stringify(srcConnector), constant.paramsHTTPWithJwt), {
+            [`[with random "jwt-sub" header] PATCH /v1alpha/connectors/${srcConnector.id} response status for updating gRPC source connector 404`]: (r) => r.status === 404,
         });
 
-        check(http.request("DELETE", `${connectorPublicHost}/v1alpha/connectors/${gRPCSrcConnector.id}`), {
-            [`DELETE /v1alpha/connectors/${gRPCSrcConnector.id} response status 204`]: (r) => r.status === 204,
+        check(http.request("DELETE", `${connectorPublicHost}/v1alpha/connectors/${srcConnector.id}`), {
+            [`DELETE /v1alpha/connectors/${srcConnector.id} response status 204`]: (r) => r.status === 204,
         });
 
     });
@@ -116,13 +104,13 @@ export function CheckDelete() {
     group(`Connector API: Delete source connectors [with random "jwt-sub" header]`, () => {
 
         // Cannot delete source connector of a non-exist user
-        check(http.request("DELETE", `${connectorPublicHost}/v1alpha/connectors/source-http`, null, constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] DELETE /v1alpha/connectors/source-http response status 404`]: (r) => r.status === 404,
+        check(http.request("DELETE", `${connectorPublicHost}/v1alpha/connectors/trigger`, null, constant.paramsHTTPWithJwt), {
+            [`[with random "jwt-sub" header] DELETE /v1alpha/connectors/trigger response status 404`]: (r) => r.status === 404,
         });
 
         // Cannot delete destination connector of a non-exist user
-        check(http.request("DELETE", `${connectorPublicHost}/v1alpha/connectors/destination-http`, null, constant.paramsHTTPWithJwt), {
-            [`[with random "jwt-sub" header] DELETE /v1alpha/connectors/destination-http response status 404`]: (r) => r.status === 404,
+        check(http.request("DELETE", `${connectorPublicHost}/v1alpha/connectors/response`, null, constant.paramsHTTPWithJwt), {
+            [`[with random "jwt-sub" header] DELETE /v1alpha/connectors/response response status 404`]: (r) => r.status === 404,
         });
     });
 }
@@ -131,14 +119,14 @@ export function CheckLookUp() {
 
     group(`Connector API: Look up source connectors by UID [with random "jwt-sub" header]`, () => {
 
-        var httpSrcConnector = {
-            "id": "source-http",
-            "connector_definition_name": constant.httpSrcDefRscName,
+        var srcConnector = {
+            "id": "trigger",
+            "connector_definition_name": constant.srcDefRscName,
             "configuration": {}
         }
 
         var resHTTP = http.request("POST", `${connectorPublicHost}/v1alpha/connectors`,
-            JSON.stringify(httpSrcConnector), constant.params)
+            JSON.stringify(srcConnector), constant.params)
 
         // Cannot look up source connector of a non-exist user
         check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors/${resHTTP.json().connector.uid}/lookUp`, null, constant.paramsHTTPWithJwt), {
@@ -155,14 +143,14 @@ export function CheckLookUp() {
 export function CheckState() {
 
     group(`Connector API: Change state source connectors [with random "jwt-sub" header]`, () => {
-        var httpSrcConnector = {
-            "id": "source-http",
-            "connector_definition_name": constant.httpSrcDefRscName,
+        var srcConnector = {
+            "id": "trigger",
+            "connector_definition_name": constant.srcDefRscName,
             "configuration": {}
         }
 
         var resHTTP = http.request("POST", `${connectorPublicHost}/v1alpha/connectors`,
-            JSON.stringify(httpSrcConnector), constant.params)
+            JSON.stringify(srcConnector), constant.params)
 
         // Cannot connect source connector of a non-exist user
         check(http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${resHTTP.json().connector.id}/connect`, null, constant.paramsHTTPWithJwt), {
@@ -185,14 +173,14 @@ export function CheckState() {
 export function CheckRename() {
 
     group(`Connector API: Rename source connectors [with random "jwt-sub" header]`, () => {
-        var httpSrcConnector = {
-            "id": "source-http",
-            "connector_definition_name": constant.httpSrcDefRscName,
+        var srcConnector = {
+            "id": "trigger",
+            "connector_definition_name": constant.srcDefRscName,
             "configuration": {}
         }
 
         var resHTTP = http.request("POST", `${connectorPublicHost}/v1alpha/connectors`,
-            JSON.stringify(httpSrcConnector), constant.params)
+            JSON.stringify(srcConnector), constant.params)
 
         // Cannot rename source connector of a non-exist user
         check(http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${resHTTP.json().connector.id}/rename`,
@@ -202,8 +190,8 @@ export function CheckRename() {
             [`[with random "jwt-sub" header] POST /v1alpha/connectors/${resHTTP.json().connector.id}/rename response status 404`]: (r) => r.status === 404,
         });
 
-        check(http.request("DELETE", `${connectorPublicHost}/v1alpha/connectors/${httpSrcConnector.id}`), {
-            [`DELETE /v1alpha/connectors/${httpSrcConnector.id} response status 204`]: (r) => r.status === 204,
+        check(http.request("DELETE", `${connectorPublicHost}/v1alpha/connectors/${srcConnector.id}`), {
+            [`DELETE /v1alpha/connectors/${srcConnector.id} response status 204`]: (r) => r.status === 204,
         });
     });
 
@@ -213,14 +201,14 @@ export function CheckTest() {
 
     group(`Connector API: Test source connectors by ID [with random "jwt-sub" header]`, () => {
 
-        var httpSrcConnector = {
-            "id": "source-http",
-            "connector_definition_name": constant.httpSrcDefRscName,
+        var srcConnector = {
+            "id": "trigger",
+            "connector_definition_name": constant.srcDefRscName,
             "configuration": {}
         }
 
         var resHTTP = http.request("POST", `${connectorPublicHost}/v1alpha/connectors`,
-            JSON.stringify(httpSrcConnector), constant.params)
+            JSON.stringify(srcConnector), constant.params)
 
         // Cannot test source connector of a non-exist user
         check(http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${resHTTP.json().connector.id}/testConnection`, null, constant.paramsHTTPWithJwt), {

--- a/integration-test/rest-source-connector-public.js
+++ b/integration-test/rest-source-connector-public.js
@@ -11,48 +11,34 @@ export function CheckCreate() {
 
     group("Connector API: Create source connectors", () => {
 
-        var httpSrcConnector = {
-            "id": "source-http",
-            "connector_definition_name": constant.httpSrcDefRscName,
+        var srcConnector = {
+            "id": "trigger",
+            "connector_definition_name": constant.srcDefRscName,
             "description": "HTTP source",
             "configuration": {},
         }
 
-        var gRPCSrcConnector = {
-            "id": "source-grpc",
-            "connector_definition_name": constant.gRPCSrcDefRscName,
-            "description": "gRPC source",
-            "configuration": {},
-        }
 
         var resSrcHTTP = http.request(
             "POST",
             `${connectorPublicHost}/v1alpha/connectors`,
-            JSON.stringify(httpSrcConnector), constant.params)
+            JSON.stringify(srcConnector), constant.params)
 
         check(resSrcHTTP, {
             "POST /v1alpha/connectors response status for creating HTTP source connector 201": (r) => r.status === 201,
-            "POST /v1alpha/connectors response connector name": (r) => r.json().connector.name == `connectors/${httpSrcConnector.id}`,
+            "POST /v1alpha/connectors response connector name": (r) => r.json().connector.name == `connectors/${srcConnector.id}`,
             "POST /v1alpha/connectors response connector uid": (r) => helper.isUUID(r.json().connector.uid),
-            "POST /v1alpha/connectors response connector connector_definition_name": (r) => r.json().connector.connector_definition_name === constant.httpSrcDefRscName,
+            "POST /v1alpha/connectors response connector connector_definition_name": (r) => r.json().connector.connector_definition_name === constant.srcDefRscName,
             "POST /v1alpha/connectors response connector owner is UUID": (r) => helper.isValidOwner(r.json().connector.user),
         });
 
         check(http.request(
             "POST",
             `${connectorPublicHost}/v1alpha/connectors`,
-            JSON.stringify(httpSrcConnector), constant.params), {
+            JSON.stringify(srcConnector), constant.params), {
             "POST /v1alpha/connectors response duplicate HTTP source connector status 409": (r) => r.status === 409
         });
 
-        var resSrcGRPC = http.request(
-            "POST",
-            `${connectorPublicHost}/v1alpha/connectors`,
-            JSON.stringify(gRPCSrcConnector), constant.params)
-
-        check(resSrcGRPC, {
-            "POST /v1alpha/connectors response status for creating gRPC source connector 201": (r) => r.status === 201,
-        });
 
         check(http.request(
             "POST",
@@ -64,9 +50,6 @@ export function CheckCreate() {
         // Delete test records
         check(http.request("DELETE", `${connectorPublicHost}/v1alpha/connectors/${resSrcHTTP.json().connector.id}`), {
             [`DELETE /v1alpha/connectors/${resSrcHTTP.json().connector.id} response status 204`]: (r) => r.status === 204,
-        });
-        check(http.request("DELETE", `${connectorPublicHost}/v1alpha/connectors/${resSrcGRPC.json().connector.id}`), {
-            [`DELETE /v1alpha/connectors/${resSrcGRPC.json().connector.id} response status 204`]: (r) => r.status === 204,
         });
     });
 }
@@ -84,14 +67,8 @@ export function CheckList() {
 
         var reqBodies = [];
         reqBodies[0] = {
-            "id": "source-http",
-            "connector_definition_name": constant.httpSrcDefRscName,
-            "configuration": {}
-        }
-
-        reqBodies[1] = {
-            "id": "source-grpc",
-            "connector_definition_name": constant.gRPCSrcDefRscName,
+            "id": "trigger",
+            "connector_definition_name": constant.srcDefRscName,
             "configuration": {}
         }
 
@@ -166,19 +143,19 @@ export function CheckGet() {
 
     group("Connector API: Get source connectors by ID", () => {
 
-        var httpSrcConnector = {
-            "id": "source-http",
-            "connector_definition_name": constant.httpSrcDefRscName,
+        var srcConnector = {
+            "id": "trigger",
+            "connector_definition_name": constant.srcDefRscName,
             "configuration": {}
         }
 
         var resHTTP = http.request("POST", `${connectorPublicHost}/v1alpha/connectors`,
-            JSON.stringify(httpSrcConnector), constant.params)
+            JSON.stringify(srcConnector), constant.params)
 
         check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors/${resHTTP.json().connector.id}`), {
             [`GET /v1alpha/connectors/${resHTTP.json().connector.id} response status 200`]: (r) => r.status === 200,
-            [`GET /v1alpha/connectors/${resHTTP.json().connector.id} response connector id`]: (r) => r.json().connector.id === httpSrcConnector.id,
-            [`GET /v1alpha/connectors/${resHTTP.json().connector.id} response connector connector_definition_name`]: (r) => r.json().connector.connector_definition_name === constant.httpSrcDefRscName,
+            [`GET /v1alpha/connectors/${resHTTP.json().connector.id} response connector id`]: (r) => r.json().connector.id === srcConnector.id,
+            [`GET /v1alpha/connectors/${resHTTP.json().connector.id} response connector connector_definition_name`]: (r) => r.json().connector.connector_definition_name === constant.srcDefRscName,
             [`GET /v1alpha/connectors/${resHTTP.json().connector.id} response connector owner is UUID`]: (r) => helper.isValidOwner(r.json().connector.user),
         });
 
@@ -193,33 +170,33 @@ export function CheckUpdate() {
 
     group("Connector API: Update source connectors", () => {
 
-        var gRPCSrcConnector = {
-            "id": "source-grpc",
-            "connector_definition_name": constant.gRPCSrcDefRscName,
+        var srcConnector = {
+            "id": "trigger",
+            "connector_definition_name": constant.srcDefRscName,
             "configuration": {}
         }
 
         check(http.request(
             "POST",
             `${connectorPublicHost}/v1alpha/connectors`,
-            JSON.stringify(gRPCSrcConnector), constant.params), {
+            JSON.stringify(srcConnector), constant.params), {
             "POST /v1alpha/connectors response status for creating gRPC source connector 201": (r) => r.status === 201,
         });
 
-        http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${gRPCSrcConnector.id}/connect`,
+        http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${srcConnector.id}/connect`,
             {}, constant.params)
 
-        gRPCSrcConnector.description = randomString(20)
+        srcConnector.description = randomString(20)
 
         check(http.request(
             "PATCH",
-            `${connectorPublicHost}/v1alpha/connectors/${gRPCSrcConnector.id}`,
-            JSON.stringify(gRPCSrcConnector), constant.params), {
-            [`PATCH /v1alpha/connectors/${gRPCSrcConnector.id} response status for updating gRPC source connector 422`]: (r) => r.status === 422,
+            `${connectorPublicHost}/v1alpha/connectors/${srcConnector.id}`,
+            JSON.stringify(srcConnector), constant.params), {
+            [`PATCH /v1alpha/connectors/${srcConnector.id} response status for updating gRPC source connector 422`]: (r) => r.status === 422,
         });
 
-        check(http.request("DELETE", `${connectorPublicHost}/v1alpha/connectors/${gRPCSrcConnector.id}`), {
-            [`DELETE /v1alpha/connectors/${gRPCSrcConnector.id} response status 204`]: (r) => r.status === 204,
+        check(http.request("DELETE", `${connectorPublicHost}/v1alpha/connectors/${srcConnector.id}`), {
+            [`DELETE /v1alpha/connectors/${srcConnector.id} response status 204`]: (r) => r.status === 204,
         });
 
     });
@@ -232,8 +209,8 @@ export function CheckDelete() {
 
         check(http.request("POST", `${connectorPublicHost}/v1alpha/connectors`,
             JSON.stringify({
-                "id": "source-http",
-                "connector_definition_name": "connector-definitions/source-http",
+                "id": "trigger",
+                "connector_definition_name": "connector-definitions/trigger",
                 "configuration": {}
             }), constant.params), {
             "POST /v1alpha/connectors response status for creating HTTP source connector 201": (r) => r.status === 201,
@@ -241,8 +218,8 @@ export function CheckDelete() {
 
         check(http.request("POST", `${connectorPublicHost}/v1alpha/connectors`,
             JSON.stringify({
-                "id": "destination-http",
-                "connector_definition_name": "connector-definitions/destination-http",
+                "id": "response",
+                "connector_definition_name": "connector-definitions/response",
                 "configuration": {}
             }), constant.params), {
             "POST /v1alpha/connectors response status for creating HTTP destination connector 201": (r) => r.status === 201,
@@ -277,9 +254,9 @@ export function CheckDelete() {
             recipe: {
                 "version": "v1alpha",
                 "components": [
-                    { "id": "s01", "resource_name": "connectors/source-http" },
+                    { "id": "s01", "resource_name": "connectors/trigger" },
                     { "id": "m01", "resource_name": "models/dummy-cls" },
-                    { "id": "d01", "resource_name": "connectors/destination-http" },
+                    { "id": "d01", "resource_name": "connectors/response" },
                 ]
             },
         };
@@ -297,15 +274,15 @@ export function CheckDelete() {
         })
 
         // Cannot delete source connector due to pipeline occupancy
-        check(http.request("DELETE", `${connectorPublicHost}/v1alpha/connectors/source-http`), {
-            [`DELETE /v1alpha/connectors/source-http response status 422`]: (r) => r.status === 422,
-            [`DELETE /v1alpha/connectors/source-http response error msg not nil`]: (r) => r.json() != {},
+        check(http.request("DELETE", `${connectorPublicHost}/v1alpha/connectors/trigger`), {
+            [`DELETE /v1alpha/connectors/trigger response status 422`]: (r) => r.status === 422,
+            [`DELETE /v1alpha/connectors/trigger response error msg not nil`]: (r) => r.json() != {},
         });
 
         // Cannot delete destination connector due to pipeline occupancy
-        check(http.request("DELETE", `${connectorPublicHost}/v1alpha/connectors/destination-http`), {
-            [`DELETE /v1alpha/connectors/destination-http response status 422`]: (r) => r.status === 422,
-            [`DELETE /v1alpha/connectors/source-http response error msg not nil`]: (r) => r.json() != {},
+        check(http.request("DELETE", `${connectorPublicHost}/v1alpha/connectors/response`), {
+            [`DELETE /v1alpha/connectors/response response status 422`]: (r) => r.status === 422,
+            [`DELETE /v1alpha/connectors/trigger response error msg not nil`]: (r) => r.json() != {},
         });
 
         check(http.request("DELETE", `${pipelinePublicHost}/v1alpha/pipelines/${pipelineID}`), {
@@ -313,13 +290,13 @@ export function CheckDelete() {
         });
 
         // Can delete source connector now
-        check(http.request("DELETE", `${connectorPublicHost}/v1alpha/connectors/source-http`), {
-            [`DELETE /v1alpha/connectors/source-http response status 204`]: (r) => r.status === 204,
+        check(http.request("DELETE", `${connectorPublicHost}/v1alpha/connectors/trigger`), {
+            [`DELETE /v1alpha/connectors/trigger response status 204`]: (r) => r.status === 204,
         });
 
         // Can delete destination connector now
-        check(http.request("DELETE", `${connectorPublicHost}/v1alpha/connectors/destination-http`), {
-            [`DELETE /v1alpha/connectors/destination-http response status 204`]: (r) => r.status === 204,
+        check(http.request("DELETE", `${connectorPublicHost}/v1alpha/connectors/response`), {
+            [`DELETE /v1alpha/connectors/response response status 204`]: (r) => r.status === 204,
         });
 
         // Wait for model state to be updated
@@ -348,19 +325,19 @@ export function CheckLookUp() {
 
     group("Connector API: Look up source connectors by UID", () => {
 
-        var httpSrcConnector = {
-            "id": "source-http",
-            "connector_definition_name": constant.httpSrcDefRscName,
+        var srcConnector = {
+            "id": "trigger",
+            "connector_definition_name": constant.srcDefRscName,
             "configuration": {}
         }
 
         var resHTTP = http.request("POST", `${connectorPublicHost}/v1alpha/connectors`,
-            JSON.stringify(httpSrcConnector), constant.params)
+            JSON.stringify(srcConnector), constant.params)
 
         check(http.request("GET", `${connectorPublicHost}/v1alpha/connectors/${resHTTP.json().connector.uid}/lookUp`), {
             [`GET /v1alpha/connectors/${resHTTP.json().connector.uid}/lookUp response status 200`]: (r) => r.status === 200,
             [`GET /v1alpha/connectors/${resHTTP.json().connector.uid}/lookUp response connector uid`]: (r) => r.json().connector.uid === resHTTP.json().connector.uid,
-            [`GET /v1alpha/connectors/${resHTTP.json().connector.uid}/lookUp response connector connector_definition_name`]: (r) => r.json().connector.connector_definition_name === constant.httpSrcDefRscName,
+            [`GET /v1alpha/connectors/${resHTTP.json().connector.uid}/lookUp response connector connector_definition_name`]: (r) => r.json().connector.connector_definition_name === constant.srcDefRscName,
             [`GET /v1alpha/connectors/${resHTTP.json().connector.uid}/lookUp response connector owner is UUID`]: (r) => helper.isValidOwner(r.json().connector.user),
         });
 
@@ -374,14 +351,14 @@ export function CheckLookUp() {
 export function CheckState() {
 
     group("Connector API: Change state source connectors", () => {
-        var httpSrcConnector = {
-            "id": "source-http",
-            "connector_definition_name": constant.httpSrcDefRscName,
+        var srcConnector = {
+            "id": "trigger",
+            "connector_definition_name": constant.srcDefRscName,
             "configuration": {}
         }
 
         var resHTTP = http.request("POST", `${connectorPublicHost}/v1alpha/connectors`,
-            JSON.stringify(httpSrcConnector), constant.params)
+            JSON.stringify(srcConnector), constant.params)
 
         check(http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${resHTTP.json().connector.id}/connect`, null, constant.params), {
             [`POST /v1alpha/connectors/${resHTTP.json().connector.id}/connect response status 200`]: (r) => r.status === 200,
@@ -402,14 +379,14 @@ export function CheckState() {
 export function CheckRename() {
 
     group("Connector API: Rename source connectors", () => {
-        var httpSrcConnector = {
-            "id": "source-http",
-            "connector_definition_name": constant.httpSrcDefRscName,
+        var srcConnector = {
+            "id": "trigger",
+            "connector_definition_name": constant.srcDefRscName,
             "configuration": {}
         }
 
         var resHTTP = http.request("POST", `${connectorPublicHost}/v1alpha/connectors`,
-            JSON.stringify(httpSrcConnector), constant.params)
+            JSON.stringify(srcConnector), constant.params)
 
         check(http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${resHTTP.json().connector.id}/rename`,
             JSON.stringify({
@@ -429,14 +406,14 @@ export function CheckTest() {
 
     group("Connector API: Test source connectors by ID", () => {
 
-        var httpSrcConnector = {
-            "id": "source-http",
-            "connector_definition_name": constant.httpSrcDefRscName,
+        var srcConnector = {
+            "id": "trigger",
+            "connector_definition_name": constant.srcDefRscName,
             "configuration": {}
         }
 
         var resHTTP = http.request("POST", `${connectorPublicHost}/v1alpha/connectors`,
-            JSON.stringify(httpSrcConnector), constant.params)
+            JSON.stringify(srcConnector), constant.params)
 
         check(http.request("POST", `${connectorPublicHost}/v1alpha/connectors/${resHTTP.json().connector.id}/testConnection`), {
             [`POST /v1alpha/connectors/${resHTTP.json().connector.id}/testConnection response status 200`]: (r) => r.status === 200,

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -4,3 +4,5 @@ package constant
 const DefaultOwnerID string = "instill-ai"
 const HeaderOwnerUIDKey = "jwt-sub"
 const HeaderOwnerIDKey = "owner-id"
+const TriggerConnectorId = "trigger"
+const ResponseConnectorId = "response"

--- a/pkg/db/migration/000004_init.up.sql
+++ b/pkg/db/migration/000004_init.up.sql
@@ -1,0 +1,21 @@
+BEGIN;
+
+-- rename source-http to trigger
+UPDATE public.connector SET id = 'trigger'
+                        WHERE connector_definition_uid = 'f20a3c02-c70e-4e76-8566-7c13ca11d18d';
+
+-- update destination-http to trigger and rename to destination-http-deprecated
+UPDATE public.connector SET id = 'source-grpc-deprecated',
+                            connector_definition_uid = 'f20a3c02-c70e-4e76-8566-7c13ca11d18d'
+                        WHERE connector_definition_uid = '82ca7d29-a35c-4222-b900-8d6878195e7a';
+
+-- rename destination-http to trigger
+UPDATE public.connector SET id = 'response'
+                        WHERE connector_definition_uid = '909c3278-f7d1-461c-9352-87741bef11d3';
+
+-- update destination-grpc to trigger and rename to destination-grpc-deprecated
+UPDATE public.connector SET id = 'destination-grpc-deprecated',
+                            connector_definition_uid = '909c3278-f7d1-461c-9352-87741bef11d3'
+                        WHERE connector_definition_uid = 'c0e4a82c-9620-4a72-abd1-18586f2acccd';
+
+COMMIT;

--- a/pkg/handler/privateHandler.go
+++ b/pkg/handler/privateHandler.go
@@ -198,30 +198,16 @@ func (h *PrivateHandler) CheckConnector(ctx context.Context, req *connectorPB.Ch
 
 	if dbConnector.State == datamodel.ConnectorState(connectorPB.Connector_STATE_CONNECTED) {
 		state, err := h.service.CheckConnectorByUID(ctx, dbConnector.UID)
-
-		if err != nil {
-			return resp, err
-		}
-
-		_, err = h.service.UpdateConnectorState(ctx, dbConnector.ID, dbConnector.Owner, datamodel.ConnectorState(*state))
 		if err != nil {
 			return resp, err
 		}
 
 		resp.State = *state
-
 		return resp, nil
 
 	} else {
-
-		_, err = h.service.UpdateConnectorState(ctx, dbConnector.ID, dbConnector.Owner, datamodel.ConnectorState(connectorPB.Connector_STATE_DISCONNECTED))
-		if err != nil {
-			return resp, err
-		}
-
 		resp.State = connectorPB.Connector_STATE_DISCONNECTED
 		return resp, nil
-
 	}
 
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -456,14 +456,6 @@ func (s *service) UpdateConnectorID(ctx context.Context, id string, owner *mgmtP
 		return nil, st.Err()
 	}
 
-	// if err := s.DeleteResourceState(id); err != nil {
-	// 	return nil, err
-	// }
-
-	// if err := s.UpdateResourceState(newID, connectorPB.Connector_State(existingConnector.State), nil, nil); err != nil {
-	// 	return nil, err
-	// }
-
 	if err := s.repository.UpdateConnectorID(ctx, id, ownerPermalink, newID); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Because

- it is not user friendly to have separated `http` and `grpc` connector

This commit

- refactor `source-http|grpc` to `trigger` and `destination-http|grpc` to `response`
