### PR TITLE
chore: add VIEW_CONFIGURATION

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/instill-ai/connector-ai v0.3.0-alpha.0.20230829022512-d263d374bfb9
 	github.com/instill-ai/connector-blockchain v0.3.0-alpha.0.20230817135403-78ed89bf69c8
 	github.com/instill-ai/connector-data v0.3.0-alpha.0.20230829013619-dc4d97db838b
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230829012255-c03947a06bc7
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230901031716-7e3ffd7f4e18
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814155646-874e57a1e4b0
 	github.com/instill-ai/x v0.3.0-alpha
 	github.com/jackc/pgx/v5 v5.3.0

--- a/go.sum
+++ b/go.sum
@@ -756,8 +756,8 @@ github.com/instill-ai/connector-blockchain v0.3.0-alpha.0.20230817135403-78ed89b
 github.com/instill-ai/connector-blockchain v0.3.0-alpha.0.20230817135403-78ed89bf69c8/go.mod h1:+i9EwcX6pcifvjZOg6n9OvWkC8iTRi25j4miwfAcMcI=
 github.com/instill-ai/connector-data v0.3.0-alpha.0.20230829013619-dc4d97db838b h1:m79gyAj7A2RsrRJGTrJkr+P/saV2se2tKqqbQD7oeRA=
 github.com/instill-ai/connector-data v0.3.0-alpha.0.20230829013619-dc4d97db838b/go.mod h1:D10hdtGh5wmakTFR8xzKK77vhn/LT2/Ylk09AV5KGDE=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230829012255-c03947a06bc7 h1:+OhHGpOtFEG+gU5+8wL77JIEZXb9/NICJUwVLRXNARY=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230829012255-c03947a06bc7/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230901031716-7e3ffd7f4e18 h1:4s4++f9vsWvAaez19WZHotoFFutolmGOAMk/xKLS9B4=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230901031716-7e3ffd7f4e18/go.mod h1:z/L84htamlJ4QOR4jtJOaa+y3Hihu7WEqOipW0LEkmc=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814155646-874e57a1e4b0 h1:9QoCxaktvqGJYGjN8KhkWsv1DVfwbt5G1d/Ycx1kJxo=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814155646-874e57a1e4b0/go.mod h1:SELFgirs+28Wfnh0kGw02zttit4pUeKLKp17zGsTu6g=
 github.com/instill-ai/x v0.3.0-alpha h1:z9fedROOG2dVHhswBfVwU/hzHuq8/JKSUON7inF+FH8=

--- a/pkg/handler/privateHandler.go
+++ b/pkg/handler/privateHandler.go
@@ -32,13 +32,10 @@ func (h *PrivateHandler) ListConnectorResourcesAdmin(ctx context.Context, req *c
 
 	var pageSize int64
 	var pageToken string
-	var isBasicView bool
 
 	resp = &connectorPB.ListConnectorResourcesAdminResponse{}
 	pageSize = req.GetPageSize()
 	pageToken = req.GetPageToken()
-
-	isBasicView = (req.GetView() == connectorPB.View_VIEW_BASIC) || (req.GetView() == connectorPB.View_VIEW_UNSPECIFIED)
 
 	var connType connectorPB.ConnectorType
 	declarations, err := filtering.NewDeclarations([]filtering.DeclarationOption{
@@ -53,7 +50,7 @@ func (h *PrivateHandler) ListConnectorResourcesAdmin(ctx context.Context, req *c
 		return nil, err
 	}
 
-	connectorResources, totalSize, nextPageToken, err := h.service.ListConnectorResourcesAdmin(ctx, pageSize, pageToken, isBasicView, filter)
+	connectorResources, totalSize, nextPageToken, err := h.service.ListConnectorResourcesAdmin(ctx, pageSize, pageToken, parseView(req.GetView()), filter)
 	if err != nil {
 		return nil, err
 	}
@@ -69,8 +66,6 @@ func (h *PrivateHandler) ListConnectorResourcesAdmin(ctx context.Context, req *c
 func (h *PrivateHandler) LookUpConnectorResourceAdmin(ctx context.Context, req *connectorPB.LookUpConnectorResourceAdminRequest) (resp *connectorPB.LookUpConnectorResourceAdminResponse, err error) {
 
 	logger, _ := logger.GetZapLogger(ctx)
-
-	var isBasicView bool
 
 	resp = &connectorPB.LookUpConnectorResourceAdminResponse{}
 
@@ -96,9 +91,7 @@ func (h *PrivateHandler) LookUpConnectorResourceAdmin(ctx context.Context, req *
 		return nil, err
 	}
 
-	isBasicView = (req.GetView() == connectorPB.View_VIEW_BASIC) || (req.GetView() == connectorPB.View_VIEW_UNSPECIFIED)
-
-	connectorResource, err := h.service.GetConnectorResourceByUIDAdmin(ctx, connUID, isBasicView)
+	connectorResource, err := h.service.GetConnectorResourceByUIDAdmin(ctx, connUID, parseView(req.GetView()))
 	if err != nil {
 		return nil, err
 	}
@@ -110,15 +103,13 @@ func (h *PrivateHandler) LookUpConnectorResourceAdmin(ctx context.Context, req *
 
 func (h *PrivateHandler) CheckConnectorResource(ctx context.Context, req *connectorPB.CheckConnectorResourceRequest) (resp *connectorPB.CheckConnectorResourceResponse, err error) {
 
-	var isBasicView = true
-
 	resp = &connectorPB.CheckConnectorResourceResponse{}
 	connUID, err := resource.GetRscPermalinkUID(req.GetPermalink())
 	if err != nil {
 		return resp, err
 	}
 
-	connectorResource, err := h.service.GetConnectorResourceByUIDAdmin(ctx, connUID, isBasicView)
+	connectorResource, err := h.service.GetConnectorResourceByUIDAdmin(ctx, connUID, connectorPB.View_VIEW_BASIC)
 	if err != nil {
 		return nil, err
 	}
@@ -158,10 +149,9 @@ func (h *PrivateHandler) LookUpConnectorDefinitionAdmin(ctx context.Context, req
 	if err != nil {
 		return resp, err
 	}
-	isBasicView := (req.GetView() == connectorPB.View_VIEW_BASIC) || (req.GetView() == connectorPB.View_VIEW_UNSPECIFIED)
 
 	// TODO add a service wrapper
-	def, err := h.service.GetConnectorDefinitionByUIDAdmin(ctx, connUID, isBasicView)
+	def, err := h.service.GetConnectorDefinitionByUIDAdmin(ctx, connUID, parseView(req.GetView()))
 	if err != nil {
 		return resp, err
 	}

--- a/pkg/handler/utils.go
+++ b/pkg/handler/utils.go
@@ -1,0 +1,13 @@
+package handler
+
+import (
+	connectorPB "github.com/instill-ai/protogen-go/vdp/connector/v1alpha"
+)
+
+func parseView(view connectorPB.View) connectorPB.View {
+	parsedView := connectorPB.View_VIEW_BASIC
+	if view != connectorPB.View_VIEW_UNSPECIFIED {
+		parsedView = view
+	}
+	return parsedView
+}

--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -103,7 +103,7 @@ func (s *service) convertProtoToDatamodel(
 func (s *service) convertDatamodelToProto(
 	ctx context.Context,
 	dbConnectorResource *datamodel.ConnectorResource,
-	isBasicView bool,
+	view connectorPB.View,
 	credentialMask bool,
 ) (*connectorPB.ConnectorResource, error) {
 
@@ -149,12 +149,13 @@ func (s *service) convertDatamodelToProto(
 	} else if strings.HasPrefix(owner, "organizations/") {
 		pbConnectorResource.Owner = &connectorPB.ConnectorResource_Org{Org: owner}
 	}
-	if !isBasicView {
+	if view != connectorPB.View_VIEW_BASIC {
 		if credentialMask {
 			connector.MaskCredentialFields(s.connectors, dbConnDef.Id, pbConnectorResource.Configuration)
 		}
-
-		pbConnectorResource.ConnectorDefinition = dbConnDef
+		if view == connectorPB.View_VIEW_FULL {
+			pbConnectorResource.ConnectorDefinition = dbConnDef
+		}
 	}
 
 	return pbConnectorResource, nil
@@ -164,7 +165,7 @@ func (s *service) convertDatamodelToProto(
 func (s *service) convertDatamodelArrayToProtoArray(
 	ctx context.Context,
 	dbConnectorResources []*datamodel.ConnectorResource,
-	isBasicView bool,
+	view connectorPB.View,
 	credentialMask bool,
 ) ([]*connectorPB.ConnectorResource, error) {
 
@@ -174,7 +175,7 @@ func (s *service) convertDatamodelArrayToProtoArray(
 		pbConnectorResources[idx], err = s.convertDatamodelToProto(
 			ctx,
 			dbConnectorResources[idx],
-			isBasicView,
+			view,
 			credentialMask,
 		)
 		if err != nil {


### PR DESCRIPTION
Because

- we need a new view mode to return `configuration` but not return `connector_definition`

This commit

- add `VIEW_CONFIGURATION`
