### PR TITLE
chore: support param `show_deleted` to return soft-deleted connector-resources

### DIFF
--- a/cmd/init/main.go
+++ b/cmd/init/main.go
@@ -84,7 +84,7 @@ func main() {
 	})
 
 	// TODO: use pagination
-	conns, _, _, err := repository.ListConnectorResourcesAdmin(ctx, 1000, "", false, filtering.Filter{})
+	conns, _, _, err := repository.ListConnectorResourcesAdmin(ctx, 1000, "", false, filtering.Filter{}, false)
 	if err != nil {
 		panic(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/instill-ai/connector-ai v0.3.0-alpha.0.20230902023145-eff51c1635f2
 	github.com/instill-ai/connector-blockchain v0.3.0-alpha.0.20230902023142-bb1a0d67bce1
 	github.com/instill-ai/connector-data v0.3.0-alpha.0.20230902023148-56bd1d3f5c2a
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230901031716-7e3ffd7f4e18
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230906024111-95f1bd369193
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814155646-874e57a1e4b0
 	github.com/instill-ai/x v0.3.0-alpha
 	github.com/jackc/pgx/v5 v5.3.0

--- a/go.sum
+++ b/go.sum
@@ -756,8 +756,8 @@ github.com/instill-ai/connector-blockchain v0.3.0-alpha.0.20230902023142-bb1a0d6
 github.com/instill-ai/connector-blockchain v0.3.0-alpha.0.20230902023142-bb1a0d67bce1/go.mod h1:+i9EwcX6pcifvjZOg6n9OvWkC8iTRi25j4miwfAcMcI=
 github.com/instill-ai/connector-data v0.3.0-alpha.0.20230902023148-56bd1d3f5c2a h1:dsxoUQrLS/CbKq8/8+YVUxXTJ4cGk3eJzJ5S2MMq294=
 github.com/instill-ai/connector-data v0.3.0-alpha.0.20230902023148-56bd1d3f5c2a/go.mod h1:D10hdtGh5wmakTFR8xzKK77vhn/LT2/Ylk09AV5KGDE=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230901031716-7e3ffd7f4e18 h1:4s4++f9vsWvAaez19WZHotoFFutolmGOAMk/xKLS9B4=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230901031716-7e3ffd7f4e18/go.mod h1:z/L84htamlJ4QOR4jtJOaa+y3Hihu7WEqOipW0LEkmc=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230906024111-95f1bd369193 h1:b2ye7vXuatGosIQ+65rkboubrQ+y6gX5xutyKcerZiQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230906024111-95f1bd369193/go.mod h1:z/L84htamlJ4QOR4jtJOaa+y3Hihu7WEqOipW0LEkmc=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814155646-874e57a1e4b0 h1:9QoCxaktvqGJYGjN8KhkWsv1DVfwbt5G1d/Ycx1kJxo=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814155646-874e57a1e4b0/go.mod h1:SELFgirs+28Wfnh0kGw02zttit4pUeKLKp17zGsTu6g=
 github.com/instill-ai/x v0.3.0-alpha h1:z9fedROOG2dVHhswBfVwU/hzHuq8/JKSUON7inF+FH8=

--- a/pkg/handler/privateHandler.go
+++ b/pkg/handler/privateHandler.go
@@ -50,7 +50,7 @@ func (h *PrivateHandler) ListConnectorResourcesAdmin(ctx context.Context, req *c
 		return nil, err
 	}
 
-	connectorResources, totalSize, nextPageToken, err := h.service.ListConnectorResourcesAdmin(ctx, pageSize, pageToken, parseView(req.GetView()), filter)
+	connectorResources, totalSize, nextPageToken, err := h.service.ListConnectorResourcesAdmin(ctx, pageSize, pageToken, parseView(req.GetView()), filter, req.GetShowDeleted())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/handler/publicHandler.go
+++ b/pkg/handler/publicHandler.go
@@ -173,7 +173,7 @@ func (h *PublicHandler) ListConnectorResources(ctx context.Context, req *connect
 		return resp, err
 	}
 
-	connectorResources, totalSize, nextPageToken, err := h.service.ListConnectorResources(ctx, userUid, pageSize, pageToken, parseView(req.GetView()), filter)
+	connectorResources, totalSize, nextPageToken, err := h.service.ListConnectorResources(ctx, userUid, pageSize, pageToken, parseView(req.GetView()), filter, req.GetShowDeleted())
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return resp, err
@@ -465,7 +465,7 @@ func (h *PublicHandler) ListUserConnectorResources(ctx context.Context, req *con
 		return resp, err
 	}
 
-	connectorResources, totalSize, nextPageToken, err := h.service.ListUserConnectorResources(ctx, ns, userUid, pageSize, pageToken, parseView(req.GetView()), filter)
+	connectorResources, totalSize, nextPageToken, err := h.service.ListUserConnectorResources(ctx, ns, userUid, pageSize, pageToken, parseView(req.GetView()), filter, req.GetShowDeleted())
 	if err != nil {
 		span.SetStatus(1, err.Error())
 		return resp, err

--- a/pkg/service/convert.go
+++ b/pkg/service/convert.go
@@ -129,6 +129,7 @@ func (s *service) convertDatamodelToProto(
 		Tombstone:   dbConnectorResource.Tombstone,
 		CreateTime:  timestamppb.New(dbConnectorResource.CreateTime),
 		UpdateTime:  timestamppb.New(dbConnectorResource.UpdateTime),
+		DeleteTime:  timestamppb.New(dbConnectorResource.DeleteTime.Time),
 		Visibility:  connectorPB.ConnectorResource_Visibility(dbConnectorResource.Visibility),
 
 		Configuration: func() *structpb.Struct {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -44,16 +44,16 @@ type Service interface {
 	GetConnectorDefinitionByUIDAdmin(ctx context.Context, uid uuid.UUID, view connectorPB.View) (*connectorPB.ConnectorDefinition, error)
 
 	// Connector common
-	ListConnectorResources(ctx context.Context, userUid uuid.UUID, pageSize int64, pageToken string, view connectorPB.View, filter filtering.Filter) ([]*connectorPB.ConnectorResource, int64, string, error)
+	ListConnectorResources(ctx context.Context, userUid uuid.UUID, pageSize int64, pageToken string, view connectorPB.View, filter filtering.Filter, showDeleted bool) ([]*connectorPB.ConnectorResource, int64, string, error)
 	CreateUserConnectorResource(ctx context.Context, ns resource.Namespace, userUid uuid.UUID, connectorResource *connectorPB.ConnectorResource) (*connectorPB.ConnectorResource, error)
-	ListUserConnectorResources(ctx context.Context, ns resource.Namespace, userUid uuid.UUID, pageSize int64, pageToken string, view connectorPB.View, filter filtering.Filter) ([]*connectorPB.ConnectorResource, int64, string, error)
+	ListUserConnectorResources(ctx context.Context, ns resource.Namespace, userUid uuid.UUID, pageSize int64, pageToken string, view connectorPB.View, filter filtering.Filter, showDeleted bool) ([]*connectorPB.ConnectorResource, int64, string, error)
 	GetUserConnectorResourceByID(ctx context.Context, ns resource.Namespace, userUid uuid.UUID, id string, view connectorPB.View, credentialMask bool) (*connectorPB.ConnectorResource, error)
 	UpdateUserConnectorResourceByID(ctx context.Context, ns resource.Namespace, userUid uuid.UUID, id string, connectorResource *connectorPB.ConnectorResource) (*connectorPB.ConnectorResource, error)
 	UpdateUserConnectorResourceIDByID(ctx context.Context, ns resource.Namespace, userUid uuid.UUID, id string, newID string) (*connectorPB.ConnectorResource, error)
 	UpdateUserConnectorResourceStateByID(ctx context.Context, ns resource.Namespace, userUid uuid.UUID, id string, state connectorPB.ConnectorResource_State) (*connectorPB.ConnectorResource, error)
 	DeleteUserConnectorResourceByID(ctx context.Context, ns resource.Namespace, userUid uuid.UUID, id string) error
 
-	ListConnectorResourcesAdmin(ctx context.Context, pageSize int64, pageToken string, view connectorPB.View, filter filtering.Filter) ([]*connectorPB.ConnectorResource, int64, string, error)
+	ListConnectorResourcesAdmin(ctx context.Context, pageSize int64, pageToken string, view connectorPB.View, filter filtering.Filter, showDeleted bool) ([]*connectorPB.ConnectorResource, int64, string, error)
 	GetConnectorResourceByUIDAdmin(ctx context.Context, uid uuid.UUID, view connectorPB.View) (*connectorPB.ConnectorResource, error)
 
 	// Execute connector
@@ -344,11 +344,11 @@ func (s *service) GetConnectorDefinitionByUIDAdmin(ctx context.Context, uid uuid
 	return def, nil
 }
 
-func (s *service) ListConnectorResources(ctx context.Context, userUid uuid.UUID, pageSize int64, pageToken string, view connectorPB.View, filter filtering.Filter) ([]*connectorPB.ConnectorResource, int64, string, error) {
+func (s *service) ListConnectorResources(ctx context.Context, userUid uuid.UUID, pageSize int64, pageToken string, view connectorPB.View, filter filtering.Filter, showDeleted bool) ([]*connectorPB.ConnectorResource, int64, string, error) {
 
 	userPermalink := resource.UserUidToUserPermalink(userUid)
 
-	dbConnectorResources, totalSize, nextPageToken, err := s.repository.ListConnectorResources(ctx, userPermalink, pageSize, pageToken, view == connectorPB.View_VIEW_BASIC, filter)
+	dbConnectorResources, totalSize, nextPageToken, err := s.repository.ListConnectorResources(ctx, userPermalink, pageSize, pageToken, view == connectorPB.View_VIEW_BASIC, filter, showDeleted)
 	if err != nil {
 		return nil, 0, "", err
 	}
@@ -433,11 +433,11 @@ func (s *service) CreateUserConnectorResource(ctx context.Context, ns resource.N
 
 }
 
-func (s *service) ListUserConnectorResources(ctx context.Context, ns resource.Namespace, userUid uuid.UUID, pageSize int64, pageToken string, view connectorPB.View, filter filtering.Filter) ([]*connectorPB.ConnectorResource, int64, string, error) {
+func (s *service) ListUserConnectorResources(ctx context.Context, ns resource.Namespace, userUid uuid.UUID, pageSize int64, pageToken string, view connectorPB.View, filter filtering.Filter, showDeleted bool) ([]*connectorPB.ConnectorResource, int64, string, error) {
 
 	ownerPermalink := ns.String()
 	userPermalink := resource.UserUidToUserPermalink(userUid)
-	dbConnectorResources, totalSize, nextPageToken, err := s.repository.ListUserConnectorResources(ctx, ownerPermalink, userPermalink, pageSize, pageToken, view == connectorPB.View_VIEW_BASIC, filter)
+	dbConnectorResources, totalSize, nextPageToken, err := s.repository.ListUserConnectorResources(ctx, ownerPermalink, userPermalink, pageSize, pageToken, view == connectorPB.View_VIEW_BASIC, filter, showDeleted)
 
 	if err != nil {
 		return nil, 0, "", err
@@ -448,9 +448,9 @@ func (s *service) ListUserConnectorResources(ctx context.Context, ns resource.Na
 
 }
 
-func (s *service) ListConnectorResourcesAdmin(ctx context.Context, pageSize int64, pageToken string, view connectorPB.View, filter filtering.Filter) ([]*connectorPB.ConnectorResource, int64, string, error) {
+func (s *service) ListConnectorResourcesAdmin(ctx context.Context, pageSize int64, pageToken string, view connectorPB.View, filter filtering.Filter, showDeleted bool) ([]*connectorPB.ConnectorResource, int64, string, error) {
 
-	dbConnectorResources, totalSize, nextPageToken, err := s.repository.ListConnectorResourcesAdmin(ctx, pageSize, pageToken, view == connectorPB.View_VIEW_BASIC, filter)
+	dbConnectorResources, totalSize, nextPageToken, err := s.repository.ListConnectorResourcesAdmin(ctx, pageSize, pageToken, view == connectorPB.View_VIEW_BASIC, filter, showDeleted)
 	if err != nil {
 		return nil, 0, "", err
 	}


### PR DESCRIPTION
Because

- we need to return soft-deleted connector-resources when needed

This commit

- support param `show_deleted` to return soft-deleted connector-resources
