### PR TITLE
chore: increase grpc message size limit

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -166,6 +166,9 @@ func main() {
 
 	repository := repository.NewRepository(db)
 
+	grpcServerOpts = append(grpcServerOpts, grpc.MaxRecvMsgSize(constant.MaxPayloadSize))
+	grpcServerOpts = append(grpcServerOpts, grpc.MaxSendMsgSize(constant.MaxPayloadSize))
+
 	privateGrpcS := grpc.NewServer(grpcServerOpts...)
 	reflection.Register(privateGrpcS)
 

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -1,5 +1,7 @@
 package constant
 
+const MaxPayloadSize = 1024 * 1024 * 32
+
 // Constants for resource owner
 const DefaultUserID string = "instill-ai"
 const HeaderUserUIDKey = "jwt-sub"


### PR DESCRIPTION
Because

- the default grpc message size limit is only 4MB, which is not enough

This commit

- increase grpc message size limit to 32MB
