### PR TITLE
fix(proto,handler): use `int32` in proto pkg to prevent the `total_size` converted to `string`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/instill-ai/connector-ai v0.4.0-alpha
 	github.com/instill-ai/connector-blockchain v0.4.0-alpha
 	github.com/instill-ai/connector-data v0.4.0-alpha
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230906024111-95f1bd369193
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230914101327-aa4d53e6c5fc
 	github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814155646-874e57a1e4b0
 	github.com/instill-ai/x v0.3.0-alpha
 	github.com/jackc/pgx/v5 v5.3.0

--- a/go.sum
+++ b/go.sum
@@ -756,8 +756,8 @@ github.com/instill-ai/connector-blockchain v0.4.0-alpha h1:Ns3byuv3o+hZF5k52RH5X
 github.com/instill-ai/connector-blockchain v0.4.0-alpha/go.mod h1:PwUkXhQSKugveRsYNaF1730jaKcNbNqE8iz2WKbE+L4=
 github.com/instill-ai/connector-data v0.4.0-alpha h1:DZnMBAV8DTjyemSUMjxQmlBS9iwq5ALNiSeZKfvaexI=
 github.com/instill-ai/connector-data v0.4.0-alpha/go.mod h1:ah1dFHwCt1PTLiJTWtGfPG0b6IS/0lIhbCQS7WnqdX4=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230906024111-95f1bd369193 h1:b2ye7vXuatGosIQ+65rkboubrQ+y6gX5xutyKcerZiQ=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230906024111-95f1bd369193/go.mod h1:z/L84htamlJ4QOR4jtJOaa+y3Hihu7WEqOipW0LEkmc=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230914101327-aa4d53e6c5fc h1:RGrUkr9dnUxQs74/x1lWdLhIODnr6m6dZ/6UY+n08qw=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230914101327-aa4d53e6c5fc/go.mod h1:z/L84htamlJ4QOR4jtJOaa+y3Hihu7WEqOipW0LEkmc=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814155646-874e57a1e4b0 h1:9QoCxaktvqGJYGjN8KhkWsv1DVfwbt5G1d/Ycx1kJxo=
 github.com/instill-ai/usage-client v0.2.4-alpha.0.20230814155646-874e57a1e4b0/go.mod h1:SELFgirs+28Wfnh0kGw02zttit4pUeKLKp17zGsTu6g=
 github.com/instill-ai/x v0.3.0-alpha h1:z9fedROOG2dVHhswBfVwU/hzHuq8/JKSUON7inF+FH8=

--- a/pkg/handler/privateHandler.go
+++ b/pkg/handler/privateHandler.go
@@ -34,7 +34,7 @@ func (h *PrivateHandler) ListConnectorResourcesAdmin(ctx context.Context, req *c
 	var pageToken string
 
 	resp = &connectorPB.ListConnectorResourcesAdminResponse{}
-	pageSize = req.GetPageSize()
+	pageSize = int64(req.GetPageSize())
 	pageToken = req.GetPageToken()
 
 	var connType connectorPB.ConnectorType
@@ -57,7 +57,7 @@ func (h *PrivateHandler) ListConnectorResourcesAdmin(ctx context.Context, req *c
 
 	resp.ConnectorResources = connectorResources
 	resp.NextPageToken = nextPageToken
-	resp.TotalSize = totalSize
+	resp.TotalSize = int32(totalSize)
 
 	return resp, nil
 

--- a/pkg/handler/publicHandler.go
+++ b/pkg/handler/publicHandler.go
@@ -73,7 +73,7 @@ func (h *PublicHandler) ListConnectorDefinitions(ctx context.Context, req *conne
 	logger, _ := logger.GetZapLogger(ctx)
 
 	resp = &connectorPB.ListConnectorDefinitionsResponse{}
-	pageSize := req.GetPageSize()
+	pageSize := int64(req.GetPageSize())
 	pageToken := req.GetPageToken()
 
 	var connType connectorPB.ConnectorType
@@ -98,7 +98,7 @@ func (h *PublicHandler) ListConnectorDefinitions(ctx context.Context, req *conne
 
 	resp.ConnectorDefinitions = defs
 	resp.NextPageToken = nextPageToken
-	resp.TotalSize = totalSize
+	resp.TotalSize = int32(totalSize)
 
 	logger.Info("ListConnectorDefinitions")
 
@@ -149,7 +149,7 @@ func (h *PublicHandler) ListConnectorResources(ctx context.Context, req *connect
 	var pageToken string
 
 	resp = &connectorPB.ListConnectorResourcesResponse{}
-	pageSize = req.GetPageSize()
+	pageSize = int64(req.GetPageSize())
 	pageToken = req.GetPageToken()
 
 	var connType connectorPB.ConnectorType
@@ -188,7 +188,7 @@ func (h *PublicHandler) ListConnectorResources(ctx context.Context, req *connect
 
 	resp.ConnectorResources = connectorResources
 	resp.NextPageToken = nextPageToken
-	resp.TotalSize = totalSize
+	resp.TotalSize = int32(totalSize)
 
 	return resp, nil
 
@@ -436,7 +436,7 @@ func (h *PublicHandler) ListUserConnectorResources(ctx context.Context, req *con
 	var pageToken string
 
 	resp = &connectorPB.ListUserConnectorResourcesResponse{}
-	pageSize = req.GetPageSize()
+	pageSize = int64(req.GetPageSize())
 	pageToken = req.GetPageToken()
 
 	var connType connectorPB.ConnectorType
@@ -480,7 +480,7 @@ func (h *PublicHandler) ListUserConnectorResources(ctx context.Context, req *con
 
 	resp.ConnectorResources = connectorResources
 	resp.NextPageToken = nextPageToken
-	resp.TotalSize = totalSize
+	resp.TotalSize = int32(totalSize)
 
 	return resp, nil
 

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -84,7 +84,7 @@ func (u *usage) RetrieveUsageData() interface{} {
 
 	// Roll over all users and update the metrics with the cached uuid
 	userPageToken := ""
-	userPageSizeMax := int64(repository.MaxPageSize)
+	userPageSizeMax := int32(repository.MaxPageSize)
 
 	for {
 		userResp, err := u.mgmtPrivateServiceClient.ListUsersAdmin(ctx, &mgmtPB.ListUsersAdminRequest{


### PR DESCRIPTION
Because

- the grpc-gateway will convert `int64` to `string`

This commit

- use `int32` for `page_size` and `total_size` to avoid this problem
