### PR TITLE
chore(service): remove unsafe user_id injection and update default_user_id

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -12,7 +12,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/gofrs/uuid"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/contrib/propagators/b3"
@@ -42,7 +41,6 @@ import (
 
 	database "github.com/instill-ai/connector-backend/pkg/db"
 	custom_otel "github.com/instill-ai/connector-backend/pkg/logger/otel"
-	mgmtPB "github.com/instill-ai/protogen-go/base/mgmt/v1alpha"
 	connectorPB "github.com/instill-ai/protogen-go/vdp/connector/v1alpha"
 )
 
@@ -175,12 +173,6 @@ func main() {
 	publicGrpcS := grpc.NewServer(grpcServerOpts...)
 	reflection.Register(publicGrpcS)
 
-	resp, err := mgmtPrivateServiceClient.GetUserAdmin(ctx, &mgmtPB.GetUserAdminRequest{Name: "users/" + constant.DefaultUserID})
-	if err != nil {
-		panic(err)
-	}
-	defaultUserUID := uuid.FromStringOrNil(*resp.User.Uid)
-
 	service := service.NewService(
 		ctx,
 		repository,
@@ -189,7 +181,6 @@ func main() {
 		controllerClient,
 		redisClient,
 		influxDBWriteClient,
-		defaultUserUID,
 	)
 	connectorPB.RegisterConnectorPrivateServiceServer(
 		privateGrpcS,

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -3,5 +3,5 @@ package constant
 const MaxPayloadSize = 1024 * 1024 * 32
 
 // Constants for resource owner
-const DefaultUserID string = "instill-ai"
+const DefaultUserID string = "admin"
 const HeaderUserUIDKey = "jwt-sub"

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -87,7 +87,6 @@ type service struct {
 	connectorAll                connectorBase.IConnector
 	influxDBWriteClient         api.WriteAPI
 	redisClient                 *redis.Client
-	defaultUserUid              uuid.UUID
 	connectors                  connectorBase.IConnector
 }
 
@@ -100,7 +99,6 @@ func NewService(
 	c controllerPB.ControllerPrivateServiceClient,
 	rc *redis.Client,
 	i api.WriteAPI,
-	defaultUserUid uuid.UUID,
 ) Service {
 	logger, _ := logger.GetZapLogger(t)
 	return &service{
@@ -111,7 +109,6 @@ func NewService(
 		connectorAll:                connector.InitConnectorAll(logger),
 		redisClient:                 rc,
 		influxDBWriteClient:         i,
-		defaultUserUid:              defaultUserUid,
 		connectors:                  connector.InitConnectorAll(logger),
 	}
 }
@@ -130,10 +127,9 @@ func (s *service) GetUser(ctx context.Context) (string, uuid.UUID, error) {
 			return "", uuid.Nil, status.Errorf(codes.Unauthenticated, "Unauthorized")
 		}
 
-		return *userResp.User.Uid, uuid.FromStringOrNil(headerUserUId), nil
+		return userResp.User.Id, uuid.FromStringOrNil(headerUserUId), nil
 	}
-
-	return constant.DefaultUserID, s.defaultUserUid, nil
+	return "", uuid.Nil, status.Errorf(codes.Unauthenticated, "Unauthorized")
 }
 
 func (s *service) injectUserToContext(ctx context.Context, userPermalink string) context.Context {


### PR DESCRIPTION
Because

- the `user_id` injection in backend is unsafe
- we are going to change the default_user_id to `admin`

This commit

- remove `user_id` injection
- change the default_user_id to `admin`
