### PR TITLE
docs(contributing): update contributing guidelines and labeler

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -13,9 +13,66 @@ Please refer to the [community contributing section](https://github.com/instill-
 
 Before delving into the details to come up with your first PR, please familiarise yourself with the project structure of [Instill Core](https://github.com/instill-ai/community#instill-core).
 
-### Prerequisites & Development
+### Prerequisites
 
-Please refer to [here](../README.md).
+- [Instill VDP](https://github.com/instill-ai/vdp)
+
+### Pre-commit hooks
+
+check out `.pre-commit-config.yaml` for the set of hooks that we used
+
+### Local development
+
+On the local machine, clone `vdp` repository in your workspace, move to the repository folder, and launch all dependent microservices:
+```bash
+$ cd <your-workspace>
+$ git clone https://github.com/instill-ai/vdp.git
+$ cd vdp
+$ make latest PROFILE=connector ITMODE_ENABLED=true
+```
+
+Clone `connector-backend` repository in your workspace and move to the repository folder:
+```bash
+$ cd <your-workspace>
+$ git clone https://github.com/instill-ai/connector-backend.git
+$ cd connector-backend
+```
+
+### Build the dev image
+
+```bash
+$ make build
+```
+
+### Run the dev container
+
+```bash
+$ make dev
+```
+
+Now, you have the Go project set up in the container, in which you can compile and run the binaries together with the integration test in each container shell.
+
+### Run the server
+
+```bash
+$ docker exec -it connector-backend /bin/bash
+$ go run ./cmd/migration
+$ go run ./cmd/init
+$ go run ./cmd/main
+```
+
+### Run the integration test
+
+``` bash
+$ docker exec -it connector-backend /bin/bash
+$ make integration-test
+```
+
+### Stop the dev container
+
+```bash
+$ make stop
+```
 
 ### Sending PRs
 
@@ -31,6 +88,17 @@ Please take these general guidelines into consideration when you are sending a P
 5. **Open a Pull Request:** Initiate a pull request to our repository. Our team will review your changes and collaborate with you on any necessary refinements.
 
 When you are ready to send a PR, we recommend you to first open a `draft` one. This will trigger a bunch of `tests` [workflows](https://github.com/instill-ai/connector-backend/tree/main/.github/workflows) running a thorough test suite on multiple platforms. After the tests are done and passed, you can now mark the PR `open` to notify the codebase owners to review. We appreciate your endeavour to pass the integration test for your PR to make sure the sanity with respect to the entire scope of **Instill Core**.
+
+### CI/CD
+
+- **pull_request** to the `main` branch will trigger the **`Integration Test`** workflow running the integration test using the image built on the PR head branch.
+- **push** to the `main` branch will trigger
+  - the **`Integration Test`** workflow building and pushing the `:latest` image on the `main` branch, following by running the integration test, and
+  - the **`Release Please`** workflow, which will create and update a PR with respect to the up-to-date `main` branch using [release-please-action](https://github.com/google-github-actions/release-please-action).
+
+Once the release PR is merged to the `main` branch, the [release-please-action](https://github.com/google-github-actions/release-please-action) will tag and release a version correspondingly.
+
+The images are pushed to Docker Hub [repository](https://hub.docker.com/r/instill/connector-backend).
 
 ## Last words
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,2 +1,2 @@
-💧 instill-vdp:
+instill vdp:
   - "**"

--- a/README.md
+++ b/README.md
@@ -2,71 +2,7 @@
 
 [![Integration Test](https://github.com/instill-ai/connector-backend/actions/workflows/integration-test.yml/badge.svg)](https://github.com/instill-ai/connector-backend/actions/workflows/integration-test.yml)
 
-`connector-backend` manages all connector resources and communicates with [Versatile Data Pipeline (VDP)](https://github.com/instill-ai/vdp) to connect a pipeline to flow the source unstructured data to the destination.
-
-## Local dev
-
-On the local machine, clone `vdp` repository in your workspace, move to the repository folder, and launch all dependent microservices:
-```bash
-$ cd <your-workspace>
-$ git clone https://github.com/instill-ai/vdp.git
-$ cd vdp
-$ make latest PROFILE=connector ITMODE_ENABLED=true
-```
-
-Clone `connector-backend` repository in your workspace and move to the repository folder:
-```bash
-$ cd <your-workspace>
-$ git clone https://github.com/instill-ai/connector-backend.git
-$ cd connector-backend
-```
-
-### Build the dev image
-
-```bash
-$ make build
-```
-
-### Run the dev container
-
-```bash
-$ make dev
-```
-
-Now, you have the Go project set up in the container, in which you can compile and run the binaries together with the integration test in each container shell.
-
-### Run the server
-
-```bash
-$ docker exec -it connector-backend /bin/bash
-$ go run ./cmd/migration
-$ go run ./cmd/init
-$ go run ./cmd/main
-```
-
-### Run the integration test
-
-``` bash
-$ docker exec -it connector-backend /bin/bash
-$ make integration-test
-```
-
-### Stop the dev container
-
-```bash
-$ make stop
-```
-
-### CI/CD
-
-- **pull_request** to the `main` branch will trigger the **`Integration Test`** workflow running the integration test using the image built on the PR head branch.
-- **push** to the `main` branch will trigger
-  - the **`Integration Test`** workflow building and pushing the `:latest` image on the `main` branch, following by running the integration test, and
-  - the **`Release Please`** workflow, which will create and update a PR with respect to the up-to-date `main` branch using [release-please-action](https://github.com/google-github-actions/release-please-action).
-
-Once the release PR is merged to the `main` branch, the [release-please-action](https://github.com/google-github-actions/release-please-action) will tag and release a version correspondingly.
-
-The images are pushed to Docker Hub [repository](https://hub.docker.com/r/instill/connector-backend).
+`connector-backend` manages all connector resources and communicates with [Versatile Data Pipeline (VDP)](https://github.com/instill-ai/vdp) to connect a pipeline to various AI/Data/Blockchain vendors.
 
 ## Contributing
 


### PR DESCRIPTION
Because

- we'd like to keep `README.md` succinct and put contributing guidelines in the repo `.github/CONTRIBUTING.md`

This commit

- move the content of local development into the repo contributing guideline.
- update Github label 
