### PR TITLE
refactor(logging): reduce unnecessary log emission

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -89,7 +89,9 @@ func main() {
 		// can't handle the error due to https://github.com/uber-go/zap/issues/880
 		_ = logger.Sync()
 	}()
-	grpc_zap.ReplaceGrpcLoggerV2(logger)
+
+	// verbosity 3 will avoid [transport] from emitting
+	grpc_zap.ReplaceGrpcLoggerV2WithVerbosity(logger, 3)
 
 	db := database.GetConnection()
 	defer database.Close(db)
@@ -110,6 +112,10 @@ func main() {
 			// will not log gRPC calls if it was a call to liveness or readiness and no error was raised
 			if err == nil {
 				if match, _ := regexp.MatchString("vdp.connector.v1alpha.ConnectorPublicService/.*ness$", fullMethodName); match {
+					return false
+				}
+				// stop logging successful private function calls
+				if match, _ := regexp.MatchString("model.model.v1alpha.ModelPrivateService/.*Admin$", fullMethodName); match {
 					return false
 				}
 			}

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -115,7 +115,7 @@ func main() {
 					return false
 				}
 				// stop logging successful private function calls
-				if match, _ := regexp.MatchString("model.model.v1alpha.ModelPrivateService/.*Admin$", fullMethodName); match {
+				if match, _ := regexp.MatchString("vdp.connector.v1alpha.ConnectorPrivateService/.*Admin$", fullMethodName); match {
 					return false
 				}
 			}


### PR DESCRIPTION
Because

- Currently backends in Instill Base Instill VDP and Instill Model will emit a huge amount of logs with level Info, which can overwhelm stdout

This commit

- Refactor grpc logger `verbosity` and bypass successful private function calls