### PR TITLE
ci(workflow): update github action default token

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,10 +6,13 @@ jobs:
   codecov:
     name: codecov
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.botGitHubToken }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Load .env file
         uses: cardinalby/export-env-action@v2

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -59,12 +59,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: dropletbot
-          password: ${{ secrets.botDockerHubPassword }}
-
       - name: Build image
         uses: docker/build-push-action@v3
         with:


### PR DESCRIPTION
Because

- we need to update github action default token and remove docker hub login.

This commit

- update github action default token