### PR TITLE
fix(handler): fix connector resource field can not be reset with empty value

### DIFF
--- a/pkg/handler/publicHandler.go
+++ b/pkg/handler/publicHandler.go
@@ -659,6 +659,7 @@ func (h *PublicHandler) UpdateUserConnectorResource(ctx context.Context, req *co
 		return resp, err
 	}
 	configuration := &structpb.Struct{}
+	h.service.KeepCredentialFieldsWithMaskString(dbConnDefID, pbConnectorToUpdate.Configuration)
 	proto.Merge(configuration, pbConnectorToUpdate.Configuration)
 
 	// Only the fields mentioned in the field mask will be copied to `pbPipelineToUpdate`, other fields are left intact

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -76,6 +76,7 @@ type Service interface {
 	ConvertOwnerPermalinkToName(permalink string) (string, error)
 	ConvertOwnerNameToPermalink(name string) (string, error)
 	RemoveCredentialFieldsWithMaskString(dbConnDefID string, config *structpb.Struct)
+	KeepCredentialFieldsWithMaskString(dbConnDefID string, config *structpb.Struct)
 	GetUser(ctx context.Context) (string, uuid.UUID, error)
 }
 
@@ -194,6 +195,10 @@ func (s *service) GetRscNamespaceAndPermalinkUID(path string) (resource.Namespac
 
 func (s *service) RemoveCredentialFieldsWithMaskString(dbConnDefID string, config *structpb.Struct) {
 	utils.RemoveCredentialFieldsWithMaskString(s.connectors, dbConnDefID, config)
+}
+
+func (s *service) KeepCredentialFieldsWithMaskString(dbConnDefID string, config *structpb.Struct) {
+	utils.KeepCredentialFieldsWithMaskString(s.connectors, dbConnDefID, config)
 }
 
 func (s *service) ListConnectorDefinitions(ctx context.Context, pageSize int64, pageToken string, view connectorPB.View, filter filtering.Filter) ([]*connectorPB.ConnectorDefinition, int64, string, error) {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -103,6 +103,10 @@ func RemoveCredentialFieldsWithMaskString(connector componentBase.IConnector, de
 	removeCredentialFieldsWithMaskString(connector, defId, config, "")
 }
 
+func KeepCredentialFieldsWithMaskString(connector componentBase.IConnector, defId string, config *structpb.Struct) {
+	keepCredentialFieldsWithMaskString(connector, defId, config, "")
+}
+
 func removeCredentialFieldsWithMaskString(connector componentBase.IConnector, defId string, config *structpb.Struct, prefix string) {
 
 	for k, v := range config.GetFields() {
@@ -114,6 +118,19 @@ func removeCredentialFieldsWithMaskString(connector componentBase.IConnector, de
 		}
 		if v.GetStructValue() != nil {
 			removeCredentialFieldsWithMaskString(connector, defId, v.GetStructValue(), fmt.Sprintf("%s.", key))
+		}
+
+	}
+}
+func keepCredentialFieldsWithMaskString(connector componentBase.IConnector, defId string, config *structpb.Struct, prefix string) {
+
+	for k, v := range config.GetFields() {
+		key := prefix + k
+		if !connector.IsCredentialField(defId, key) {
+			delete(config.GetFields(), k)
+		}
+		if v.GetStructValue() != nil {
+			keepCredentialFieldsWithMaskString(connector, defId, v.GetStructValue(), fmt.Sprintf("%s.", key))
 		}
 
 	}


### PR DESCRIPTION
Because

- the connector resource field can not be reset with empty value, but we should allow it

This commit

- fix bug
